### PR TITLE
feat: Rust 语言支持 (#2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-elixir",
  "tree-sitter-php",
+ "tree-sitter-rust",
  "tree-sitter-typescript",
 ]
 
@@ -508,6 +509,16 @@ name = "tree-sitter-php"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c17c3ab69052c5eeaa7ff5cd972dd1bc25d1b97ee779fec391ad3b5df5592"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/compiler/bcc/Cargo.toml
+++ b/compiler/bcc/Cargo.toml
@@ -17,6 +17,7 @@ tree-sitter = "0.25"
 tree-sitter-elixir = "0.3"
 tree-sitter-typescript = "0.23"
 tree-sitter-php = "0.24"
+tree-sitter-rust = "0.23"
 regex = "1"
 
 [dev-dependencies]

--- a/compiler/bcc/src/bugfix.rs
+++ b/compiler/bcc/src/bugfix.rs
@@ -95,7 +95,7 @@ pub fn run(
     // 验证语言
     let extensions = lang_extensions(lang);
     if extensions.is_empty() {
-        eprintln!("unsupported language: '{}'. Valid: php, elixir, typescript", lang);
+        eprintln!("unsupported language: '{}'. Valid: php, elixir, typescript, rust", lang);
         std::process::exit(1);
     }
 
@@ -144,6 +144,7 @@ fn lang_extensions(lang: &str) -> Vec<&'static str> {
         "php" => vec![".php"],
         "elixir" => vec![".ex", ".exs"],
         "typescript" | "ts" => vec![".ts", ".tsx"],
+        "rust" | "rs" => vec![".rs"],
         _ => vec![],
     }
 }
@@ -170,6 +171,13 @@ fn is_backend_file(path: &str, lang: &str) -> bool {
             (lower.contains("src/") || lower.contains("lib/"))
                 && !lower.contains("node_modules") && !lower.contains(".test.")
                 && !lower.contains(".spec.")
+        }
+        "rust" | "rs" => {
+            let lower = path.to_lowercase();
+            (lower.contains("src/") || lower.contains("lib/"))
+                && !lower.contains("target/") && !lower.contains("/tests/")
+                && !lower.contains("/benches/") && !lower.contains("/examples/")
+                && !lower.ends_with("build.rs")
         }
         _ => false,
     }
@@ -678,13 +686,14 @@ fn parse_diff_hunks(
             let ts_lang = if file_path.ends_with(".tsx") { "tsx" } else { "typescript" };
             crate::extract::typescript::extract(after_content, file_path, ts_lang)
         }
+        "rust" | "rs" => crate::extract::rust::extract(after_content, file_path),
         _ => return hunks,
     };
 
     // 对每个 export 函数，提取函数体并比较 before/after
     for export in &after_record.exports {
-        let before_func = extract_function_body(before_content, &export.name);
-        let after_func = extract_function_body(after_content, &export.name);
+        let before_func = extract_function_body(before_content, &export.name, lang);
+        let after_func = extract_function_body(after_content, &export.name, lang);
 
         if before_func != after_func && !after_func.is_empty() {
             // 计算函数范围内的改动行号
@@ -1125,13 +1134,17 @@ fn organize(output: &str, coverage_report: Option<&str>) {
     eprintln!("[organize] coverage report: {}", report_path);
 }
 
-/// 从 PHP 源码中提取指定函数名的函数体（简单实现：按大括号匹配）
-fn extract_function_body(content: &str, func_name: &str) -> String {
-    let pattern = format!("function {}", func_name);
+/// 从源码中提取指定函数名的函数体（按大括号匹配）
+fn extract_function_body(content: &str, func_name: &str, lang: &str) -> String {
+    let patterns: Vec<String> = match lang {
+        "rust" | "rs" => vec![format!("fn {}", func_name)],
+        "elixir" => vec![format!("def {}", func_name), format!("defp {}", func_name)],
+        _ => vec![format!("function {}", func_name)], // php, typescript
+    };
     let lines: Vec<&str> = content.lines().collect();
 
     for (i, line) in lines.iter().enumerate() {
-        if line.contains(&pattern) {
+        if patterns.iter().any(|p| line.contains(p.as_str())) {
             // 找到函数开头，按大括号平衡提取
             let mut depth = 0;
             let mut started = false;
@@ -1315,7 +1328,7 @@ class Foo {
         return 2;
     }
 }"#;
-        let body = extract_function_body(php, "bar");
+        let body = extract_function_body(php, "bar", "php");
         assert!(body.contains("function bar()"));
         assert!(body.contains("return 1;"));
         assert!(!body.contains("return 2;"));
@@ -1334,7 +1347,7 @@ class Foo {
         return true;
     }
 }"#;
-        let body = extract_function_body(php, "complex");
+        let body = extract_function_body(php, "complex", "php");
         assert!(body.contains("function complex()"));
         assert!(body.contains("foreach"));
         assert!(body.contains("return true;"));
@@ -1343,7 +1356,7 @@ class Foo {
     #[test]
     fn extract_nonexistent_function() {
         let php = "<?php\nclass Foo { public function bar() { return 1; } }";
-        let body = extract_function_body(php, "nonexistent");
+        let body = extract_function_body(php, "nonexistent", "php");
         assert!(body.is_empty());
     }
 

--- a/compiler/bcc/src/extract/mod.rs
+++ b/compiler/bcc/src/extract/mod.rs
@@ -4,6 +4,7 @@ use std::fs;
 pub mod elixir;
 pub mod typescript;
 pub mod php;
+pub mod rust;
 
 #[derive(Debug, Serialize)]
 pub struct FileRecord {
@@ -68,6 +69,7 @@ pub fn run(path: &str, mode: &str, output: Option<&str>) {
         "elixir" => elixir::extract(&content, path),
         "typescript" | "tsx" => typescript::extract(&content, path, &lang),
         "php" => php::extract(&content, path),
+        "rust" => rust::extract(&content, path),
         other => {
             eprintln!("unsupported language: {}", other);
             std::process::exit(1);

--- a/compiler/bcc/src/extract/rust.rs
+++ b/compiler/bcc/src/extract/rust.rs
@@ -1,0 +1,441 @@
+use tree_sitter::Parser;
+use super::*;
+
+/// 使用 tree-sitter-rust 解析源码并提取结构信息
+pub fn extract(content: &str, path: &str) -> FileRecord {
+    let mut parser = Parser::new();
+    let language = tree_sitter_rust::LANGUAGE;
+    parser.set_language(&language.into()).expect("failed to set rust grammar");
+
+    let tree = parser.parse(content, None).expect("failed to parse rust source");
+    let root = tree.root_node();
+    let source = content.as_bytes();
+
+    let mut exports = Vec::new();
+    let mut imports = Vec::new();
+    let mut calls = Vec::new();
+    let mut declarations: usize = 0;
+
+    let mut cursor = root.walk();
+    extract_recursive(
+        &mut cursor,
+        source,
+        &mut exports,
+        &mut imports,
+        &mut calls,
+        &mut declarations,
+    );
+
+    // 去重 calls
+    let mut seen = std::collections::HashSet::new();
+    calls.retain(|c| seen.insert(c.callee.clone()));
+    calls.sort_by(|a, b| a.line.cmp(&b.line).then_with(|| a.callee.cmp(&b.callee)));
+
+    // 副作用检测（关键词扫描）
+    let side_effects = detect_side_effects(content);
+
+    // 提取模块文档（首行 //! 或 /*! 注释）
+    let module_doc = extract_module_doc(content);
+
+    FileRecord {
+        language: "rust".into(),
+        file_path: path.to_string(),
+        module_doc,
+        exports,
+        imports,
+        calls,
+        local_call_targets: Vec::new(),
+        side_effects,
+        loc_lines: content.lines().count(),
+        declarations,
+    }
+}
+
+fn extract_recursive(
+    cursor: &mut tree_sitter::TreeCursor,
+    source: &[u8],
+    exports: &mut Vec<ExportRecord>,
+    imports: &mut Vec<ImportRecord>,
+    calls: &mut Vec<CallRecord>,
+    declarations: &mut usize,
+) {
+    loop {
+        let node = cursor.node();
+        let kind = node.kind();
+
+        match kind {
+            // pub fn / fn
+            "function_item" => {
+                *declarations += 1;
+                let is_pub = has_visibility(&node);
+                if let Some(name_node) = node.child_by_field_name("name") {
+                    let name = node_text(name_node, source);
+                    let signature = build_fn_signature(&node, source);
+                    if is_pub {
+                        exports.push(ExportRecord {
+                            name,
+                            kind: "function".into(),
+                            signature: Some(signature),
+                            line: node.start_position().row + 1,
+                        });
+                    }
+                }
+            }
+            // pub struct
+            "struct_item" => {
+                *declarations += 1;
+                let is_pub = has_visibility(&node);
+                if is_pub {
+                    if let Some(name_node) = node.child_by_field_name("name") {
+                        exports.push(ExportRecord {
+                            name: node_text(name_node, source),
+                            kind: "struct".into(),
+                            signature: None,
+                            line: node.start_position().row + 1,
+                        });
+                    }
+                }
+            }
+            // pub enum
+            "enum_item" => {
+                *declarations += 1;
+                let is_pub = has_visibility(&node);
+                if is_pub {
+                    if let Some(name_node) = node.child_by_field_name("name") {
+                        exports.push(ExportRecord {
+                            name: node_text(name_node, source),
+                            kind: "enum".into(),
+                            signature: None,
+                            line: node.start_position().row + 1,
+                        });
+                    }
+                }
+            }
+            // pub trait
+            "trait_item" => {
+                *declarations += 1;
+                let is_pub = has_visibility(&node);
+                if is_pub {
+                    if let Some(name_node) = node.child_by_field_name("name") {
+                        exports.push(ExportRecord {
+                            name: node_text(name_node, source),
+                            kind: "trait".into(),
+                            signature: None,
+                            line: node.start_position().row + 1,
+                        });
+                    }
+                }
+            }
+            // impl Foo / impl Trait for Foo
+            "impl_item" => {
+                *declarations += 1;
+                let impl_text = node_text(node, source);
+                // 取 impl 行的摘要（到 { 为止）
+                let summary = impl_text.lines().next().unwrap_or("")
+                    .trim_end_matches('{').trim().to_string();
+                exports.push(ExportRecord {
+                    name: summary.clone(),
+                    kind: "impl".into(),
+                    signature: Some(summary),
+                    line: node.start_position().row + 1,
+                });
+                // 递归进入 impl 块提取内部方法
+                if cursor.goto_first_child() {
+                    extract_recursive(cursor, source, exports, imports, calls, declarations);
+                    cursor.goto_parent();
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+                continue;
+            }
+            // use 声明
+            "use_declaration" => {
+                let use_text = node_text(node, source);
+                // 去掉 "use " 前缀和尾部 ";"
+                let specifier = use_text
+                    .strip_prefix("use ")
+                    .unwrap_or(&use_text)
+                    .trim_end_matches(';')
+                    .trim()
+                    .to_string();
+                if !specifier.is_empty() {
+                    imports.push(ImportRecord {
+                        specifier,
+                        kind: "use".into(),
+                    });
+                }
+            }
+            // 函数调用: foo(), module::func(), obj.method()
+            "call_expression" => {
+                if let Some(func_node) = node.child_by_field_name("function") {
+                    let callee = extract_call_name(func_node, source);
+                    if !callee.is_empty() {
+                        calls.push(CallRecord {
+                            callee,
+                            line: node.start_position().row + 1,
+                        });
+                    }
+                }
+                // 不递归进入 call_expression 内部，避免重复
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+                continue;
+            }
+            // 宏调用: println!(), vec![], format!()
+            "macro_invocation" => {
+                if let Some(macro_node) = node.child(0) {
+                    let macro_name = node_text(macro_node, source);
+                    if !macro_name.is_empty() {
+                        calls.push(CallRecord {
+                            callee: format!("{}!", macro_name),
+                            line: node.start_position().row + 1,
+                        });
+                    }
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+                continue;
+            }
+            _ => {}
+        }
+
+        // 递归子节点（已处理的 impl_item 和 call/macro 跳过）
+        if kind != "impl_item" {
+            if cursor.goto_first_child() {
+                extract_recursive(cursor, source, exports, imports, calls, declarations);
+                cursor.goto_parent();
+            }
+        }
+
+        if !cursor.goto_next_sibling() {
+            break;
+        }
+    }
+}
+
+/// 检查节点是否有 pub 可见性修饰符
+fn has_visibility(node: &tree_sitter::Node) -> bool {
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i) {
+            if child.kind() == "visibility_modifier" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// 从 function_item 构建函数签名：fn foo(a: i32, b: &str) -> Result<T, E>
+fn build_fn_signature(node: &tree_sitter::Node, source: &[u8]) -> String {
+    let name = node.child_by_field_name("name")
+        .map(|n| node_text(n, source))
+        .unwrap_or_default();
+
+    let params = node.child_by_field_name("parameters")
+        .map(|n| node_text(n, source))
+        .unwrap_or_else(|| "()".into());
+
+    let ret = node.child_by_field_name("return_type")
+        .map(|n| {
+            let text = node_text(n, source);
+            // return_type 节点包含 "-> Type"
+            if text.starts_with("->") {
+                format!(" {}", text.trim())
+            } else {
+                format!(" -> {}", text.trim())
+            }
+        })
+        .unwrap_or_default();
+
+    format!("fn {}{}{}", name, params, ret)
+}
+
+/// 提取调用名：identifier → "foo", scoped_identifier → "module::func",
+/// field_expression → "obj.method"
+fn extract_call_name(node: tree_sitter::Node, source: &[u8]) -> String {
+    match node.kind() {
+        "identifier" => node_text(node, source),
+        "scoped_identifier" => node_text(node, source),
+        "field_expression" => {
+            // obj.method → 提取根对象名
+            if let Some(value) = node.child_by_field_name("value") {
+                return node_text(value, source);
+            }
+            node_text(node, source)
+        }
+        _ => node_text(node, source),
+    }
+}
+
+/// 提取 //! 模块文档注释
+fn extract_module_doc(content: &str) -> Option<String> {
+    let mut doc_lines = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("//!") {
+            doc_lines.push(trimmed.trim_start_matches("//!").trim());
+        } else if trimmed.is_empty() && doc_lines.is_empty() {
+            continue;
+        } else if !doc_lines.is_empty() {
+            break;
+        } else {
+            break;
+        }
+    }
+    if doc_lines.is_empty() {
+        None
+    } else {
+        Some(doc_lines.join("\n"))
+    }
+}
+
+/// 基于全文关键词扫描的副作用分类标签
+fn detect_side_effects(content: &str) -> SideEffects {
+    SideEffects {
+        has_async: content.contains("async ") || content.contains(".await")
+            || content.contains("tokio::"),
+        has_http: content.contains("reqwest") || content.contains("hyper::")
+            || content.contains("http::"),
+        has_genserver: false,
+        has_file_io: content.contains("std::fs") || content.contains("File::open")
+            || content.contains("File::create") || content.contains("fs::read")
+            || content.contains("fs::write"),
+        has_pubsub: content.contains("channel") || content.contains("mpsc::")
+            || content.contains("broadcast::"),
+    }
+}
+
+fn node_text(node: tree_sitter::Node, source: &[u8]) -> String {
+    node.utf8_text(source).unwrap_or("").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_pub_functions_and_structs() {
+        let source = r#"
+use std::collections::HashMap;
+
+pub struct Config {
+    name: String,
+}
+
+pub fn run(config: &Config) -> Result<(), String> {
+    println!("running");
+    Ok(())
+}
+
+fn private_helper() {}
+"#;
+        let record = extract(source, "src/lib.rs");
+        let export_names: Vec<_> = record.exports.iter().map(|e| e.name.as_str()).collect();
+        assert!(export_names.contains(&"Config"), "should export Config struct");
+        assert!(export_names.contains(&"run"), "should export run function");
+        // private_helper 不应出现在 exports
+        assert!(!export_names.contains(&"private_helper"), "should not export private fn");
+
+        // 验证 imports
+        assert_eq!(record.imports.len(), 1);
+        assert_eq!(record.imports[0].specifier, "std::collections::HashMap");
+
+        // 验证 calls 包含 println! 宏
+        let call_names: Vec<_> = record.calls.iter().map(|c| c.callee.as_str()).collect();
+        assert!(call_names.contains(&"println!"), "should detect println! macro call");
+
+        // 验证签名
+        let run_export = record.exports.iter().find(|e| e.name == "run").unwrap();
+        assert!(run_export.signature.as_ref().unwrap().contains("-> Result<(), String>"));
+    }
+
+    #[test]
+    fn extracts_impl_and_trait() {
+        let source = r#"
+pub trait Handler {
+    fn handle(&self);
+}
+
+pub struct Server;
+
+impl Handler for Server {
+    fn handle(&self) {
+        self.process();
+    }
+}
+
+impl Server {
+    pub fn new() -> Self { Server }
+    fn process(&self) {}
+}
+"#;
+        let record = extract(source, "src/server.rs");
+        let kinds: Vec<_> = record.exports.iter().map(|e| e.kind.as_str()).collect();
+        assert!(kinds.contains(&"trait"), "should export trait");
+        assert!(kinds.contains(&"struct"), "should export struct");
+        assert!(kinds.contains(&"impl"), "should export impl blocks");
+    }
+
+    #[test]
+    fn extracts_enum_and_use() {
+        let source = r#"
+use serde::{Serialize, Deserialize};
+use std::fmt;
+
+pub enum Status {
+    Active,
+    Inactive,
+}
+
+impl fmt::Display for Status {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+"#;
+        let record = extract(source, "src/model.rs");
+        assert_eq!(record.imports.len(), 2);
+
+        let enum_exports: Vec<_> = record.exports.iter()
+            .filter(|e| e.kind == "enum")
+            .collect();
+        assert_eq!(enum_exports.len(), 1);
+        assert_eq!(enum_exports[0].name, "Status");
+    }
+
+    #[test]
+    fn detects_side_effects() {
+        let source = r#"
+use tokio::fs;
+use reqwest::Client;
+
+pub async fn fetch_data() -> Result<String, Box<dyn std::error::Error>> {
+    let client = Client::new();
+    let body = client.get("http://example.com").send().await?.text().await?;
+    fs::write("output.txt", &body).await?;
+    Ok(body)
+}
+"#;
+        let record = extract(source, "src/fetcher.rs");
+        assert!(record.side_effects.has_async, "should detect async");
+        assert!(record.side_effects.has_http, "should detect http (reqwest)");
+        assert!(!record.side_effects.has_genserver, "rust has no genserver");
+    }
+
+    #[test]
+    fn extracts_module_doc() {
+        let source = r#"//! 这个模块负责处理用户认证
+//! 支持 JWT 和 session 两种方式
+
+use crate::auth;
+
+pub fn login() {}
+"#;
+        let record = extract(source, "src/auth.rs");
+        assert!(record.module_doc.is_some());
+        assert!(record.module_doc.unwrap().contains("用户认证"));
+    }
+}

--- a/compiler/bcc/src/main.rs
+++ b/compiler/bcc/src/main.rs
@@ -125,7 +125,7 @@ enum Commands {
         #[arg(short, long, value_name = "STEP")]
         step: Option<String>,
 
-        /// 源码语言：php, elixir, typescript [默认: php]
+        /// 源码语言：php, elixir, typescript, rust [默认: php]
         #[arg(short, long, default_value = "php")]
         lang: String,
 

--- a/compiler/bcc/tests/bugfix_bdd.rs
+++ b/compiler/bcc/tests/bugfix_bdd.rs
@@ -818,3 +818,183 @@ fn generate_limit_via_cli() {
 
     let _ = fs::remove_dir_all(&root);
 }
+
+// ═══════════════════════════════════════════════════════════
+// Rust 语言支持测试
+// ═══════════════════════════════════════════════════════════
+
+// ─── Rust extract 冒烟测试 ───────────────────────────────
+
+#[test]
+fn rust_extract_smoke() {
+    let root = temp_dir("bdd_rust_extract");
+    let rs_file = root.join("sample.rs");
+    write(&rs_file, r#"//! 示例模块
+
+use std::collections::HashMap;
+use serde::Serialize;
+
+pub struct Config {
+    pub name: String,
+}
+
+pub enum Status {
+    Active,
+    Inactive,
+}
+
+pub trait Handler {
+    fn handle(&self);
+}
+
+impl Handler for Config {
+    fn handle(&self) {
+        println!("{}", self.name);
+    }
+}
+
+pub fn run(config: &Config) -> Result<(), String> {
+    let map = HashMap::new();
+    println!("running {}", config.name);
+    Ok(())
+}
+
+fn private_helper() {
+    std::fs::read_to_string("file.txt").ok();
+}
+"#);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_bcc"))
+        .args(["extract", rs_file.to_str().unwrap(), "--mode", "ast"])
+        .output()
+        .expect("run bcc extract");
+    assert!(output.status.success(), "extract should succeed");
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .expect("output should be valid JSON");
+
+    // 验证语言
+    assert_eq!(json["language"], "rust");
+
+    // 验证 exports 包含 pub 声明
+    let exports = json["exports"].as_array().unwrap();
+    let export_names: Vec<&str> = exports.iter()
+        .filter_map(|e| e["name"].as_str())
+        .collect();
+    assert!(export_names.contains(&"Config"), "should export Config struct");
+    assert!(export_names.contains(&"Status"), "should export Status enum");
+    assert!(export_names.contains(&"Handler"), "should export Handler trait");
+    assert!(export_names.contains(&"run"), "should export run function");
+
+    // 验证 imports
+    let imports = json["imports"].as_array().unwrap();
+    assert!(imports.len() >= 2, "should have at least 2 imports");
+
+    // 验证 calls 包含 println! 宏
+    let calls = json["calls"].as_array().unwrap();
+    let call_names: Vec<&str> = calls.iter()
+        .filter_map(|c| c["callee"].as_str())
+        .collect();
+    assert!(call_names.contains(&"println!"), "should detect println! macro");
+
+    // 验证副作用
+    let se = &json["side_effects"];
+    assert_eq!(se["hasFileIo"], true, "should detect std::fs usage");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+// ─── Rust bugfix collect + context 端到端 ────────────────
+
+/// 创建 Rust 测试用 git 仓库，包含 2 个 bugfix commit
+fn setup_rust_bugfix_repo(root: &Path) -> PathBuf {
+    let repo = root.join("repo");
+    let src = repo.join("src");
+    fs::create_dir_all(&src).expect("create repo dirs");
+
+    let git = |args: &[&str]| {
+        Command::new("git")
+            .current_dir(&repo)
+            .args(args)
+            .output()
+            .expect("run git")
+    };
+
+    // 初始化 repo
+    write(&src.join("main.rs"), r#"pub fn run() {
+    println!("hello");
+}
+"#);
+    git(&["init"]);
+    git(&["config", "user.email", "test@bdd.com"]);
+    git(&["config", "user.name", "bdd-test"]);
+    git(&["add", "."]);
+    git(&["commit", "-m", "init: rust project"]);
+
+    // bugfix commit 1
+    write(&src.join("main.rs"), r#"pub fn run() {
+    if std::env::args().len() < 2 {
+        eprintln!("missing argument");
+        return;
+    }
+    println!("hello");
+}
+"#);
+    git(&["add", "."]);
+    git(&["commit", "-m", "fix: handle empty input"]);
+
+    // bugfix commit 2
+    write(&src.join("lib.rs"), r#"pub fn parse(input: &str) -> Result<i32, String> {
+    input.parse::<i32>().map_err(|e| e.to_string())
+}
+"#);
+    git(&["add", "."]);
+    git(&["commit", "-m", "init: add parser"]);
+
+    write(&src.join("lib.rs"), r#"pub fn parse(input: &str) -> Result<i32, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("empty input".into());
+    }
+    trimmed.parse::<i32>().map_err(|e| e.to_string())
+}
+"#);
+    git(&["add", "."]);
+    git(&["commit", "-m", "bug: parse 空字符串 panic"]);
+
+    repo
+}
+
+#[test]
+fn rust_bugfix_collect_and_context() {
+    let root = temp_dir("bdd_rust_bugfix");
+    let repo = setup_rust_bugfix_repo(&root);
+    let out = root.join("out");
+
+    // collect
+    let c = bcc_bugfix(&[
+        repo.to_str().unwrap(), "-o", out.to_str().unwrap(),
+        "--lang", "rust", "-s", "c", "--force",
+    ]);
+    assert!(c.status.success(), "collect failed: {}", String::from_utf8_lossy(&c.stderr));
+
+    // 验证 inventory.json
+    let inv: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(out.join("inventory.json")).unwrap(),
+    ).unwrap();
+    let commits = inv["commits"].as_array().unwrap();
+    assert!(commits.len() >= 1, "should have at least 1 bugfix commit, got {}", commits.len());
+
+    // context
+    let x = bcc_bugfix(&[
+        repo.to_str().unwrap(), "-o", out.to_str().unwrap(),
+        "--lang", "rust", "-s", "x", "--force",
+    ]);
+    assert!(x.status.success(), "context failed: {}", String::from_utf8_lossy(&x.stderr));
+
+    // 验证 contexts/ 有文件
+    let ctx_count = count_json_files(&out.join("contexts"));
+    assert!(ctx_count >= 1, "should have at least 1 context file, got {}", ctx_count);
+
+    let _ = fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
## Summary

- 新增 Rust extractor (`extract/rust.rs`)，基于 tree-sitter-rust 解析 struct/enum/trait/fn/impl/macro
- bugfix collect/context 支持 `--lang rust`，识别 `.rs` 文件和 Rust 项目结构
- `extract_function_body()` 改造为多语言感知（fn for Rust, def/defp for Elixir）
- 新增 Rust extract 冒烟测试 + bugfix collect+context 端到端测试

Closes #2

## Test plan

- [x] `cargo test` 全部通过（92 单元 + 17 集成 + 5 CLI）
- [x] `bcc extract sample.rs --mode ast` 正确输出 Rust FileRecord
- [x] `bcc bugfix <rust-repo> --lang rust -s x` 端到端可用

🤖 Generated with [Claude Code](https://claude.com/claude-code)