### PR TITLE
feat: arch validate --export-bdd-source 输出 BDD source YAML

### DIFF
--- a/compiler/bcc/src/arch.rs
+++ b/compiler/bcc/src/arch.rs
@@ -677,9 +677,7 @@ fn evaluate_scenario(
     }
 
     unexpected_top.sort_by(|a, b| b.1.cmp(&a.1));
-    unexpected_top.truncate(10);
     forbidden_top.sort_by(|a, b| b.1.cmp(&a.1));
-    forbidden_top.truncate(10);
 
     EvalResult {
         name: name.to_string(),
@@ -814,6 +812,35 @@ fn to_tsv(headers: &[&str], rows: &[Vec<String>]) -> String {
     out
 }
 
+/// 解析 edge_key "caller->callee" 为 (caller, callee)
+fn parse_edge_key(key: &str) -> Option<(&str, &str)> {
+    key.split_once("->")
+}
+
+/// 生成一个 bdd seed 可消费的 YAML source 文件
+fn write_bdd_source_yaml(
+    dir: &Path,
+    caller: &str,
+    callee: &str,
+    edge_class: &str,
+    weight: i64,
+) -> Result<(), String> {
+    let filename = format!("{}_{}.yaml", caller, callee);
+    let content = format!(
+        "module: {}\ncontract: {} -> {} arch violation\nedge_class: {}\nsource_file: arch-validate-export\nsource_summary: \"{} dependency {}->{}  (weight: {})\"\n",
+        caller.to_ascii_uppercase(),
+        caller,
+        callee,
+        edge_class,
+        edge_class,
+        caller,
+        callee,
+        weight
+    );
+    let path = dir.join(&filename);
+    fs::write(&path, &content).map_err(|e| format!("write {} failed: {}", path.display(), e))
+}
+
 pub fn validate(
     target_path: &str,
     transition_path: &str,
@@ -823,6 +850,7 @@ pub fn validate(
     profile: &str,
     fail_on_gate: bool,
     fail_on_forbidden: bool,
+    export_bdd_source: Option<&str>,
 ) {
     let code = match validate_impl(
         target_path,
@@ -833,6 +861,7 @@ pub fn validate(
         profile,
         fail_on_gate,
         fail_on_forbidden,
+        export_bdd_source,
     ) {
         Ok(code) => code,
         Err(e) => {
@@ -854,6 +883,7 @@ fn validate_impl(
     profile: &str,
     fail_on_gate: bool,
     fail_on_forbidden: bool,
+    export_bdd_source: Option<&str>,
 ) -> Result<i32, String> {
     let target_raw =
         fs::read_to_string(target_path).map_err(|e| format!("read target failed: {}", e))?;
@@ -1039,16 +1069,22 @@ fn validate_impl(
         report.push('\n');
 
         if !r.forbidden_top.is_empty() {
-            report.push_str("### Forbidden Top\n");
-            for (edge, c) in &r.forbidden_top {
+            report.push_str(&format!(
+                "### Forbidden Top (showing top 20 of {})\n",
+                r.forbidden_top.len()
+            ));
+            for (edge, c) in r.forbidden_top.iter().take(20) {
                 report.push_str(&format!("- {}: {}\n", edge, c));
             }
             report.push('\n');
         }
 
         if !r.unexpected_top.is_empty() {
-            report.push_str("### Unexpected Top\n");
-            for (edge, c) in &r.unexpected_top {
+            report.push_str(&format!(
+                "### Unexpected Top (showing top 20 of {})\n",
+                r.unexpected_top.len()
+            ));
+            for (edge, c) in r.unexpected_top.iter().take(20) {
                 report.push_str(&format!("- {}: {}\n", edge, c));
             }
             report.push('\n');
@@ -1117,6 +1153,35 @@ fn validate_impl(
         ),
     )
     .map_err(|e| format!("write summary.json failed: {}", e))?;
+
+    // 导出 bdd source YAML（如果指定了 --export-bdd-source）
+    if let Some(bdd_dir) = export_bdd_source {
+        let bdd_path = Path::new(bdd_dir);
+        fs::create_dir_all(bdd_path)
+            .map_err(|e| format!("create bdd source dir failed: {}", e))?;
+
+        let mut exported = 0usize;
+        for (key, weight) in &transition_eval.forbidden_top {
+            if let Some((caller, callee)) = parse_edge_key(key) {
+                write_bdd_source_yaml(bdd_path, caller, callee, "blocked", *weight)?;
+                exported += 1;
+            } else {
+                eprintln!("[validate] skip malformed edge key: {}", key);
+            }
+        }
+        for (key, weight) in &transition_eval.unexpected_top {
+            if let Some((caller, callee)) = parse_edge_key(key) {
+                write_bdd_source_yaml(bdd_path, caller, callee, "temporary", *weight)?;
+                exported += 1;
+            } else {
+                eprintln!("[validate] skip malformed edge key: {}", key);
+            }
+        }
+        eprintln!(
+            "[validate] exported {} bdd source files to {}",
+            exported, bdd_dir
+        );
+    }
 
     let mut code = 0;
     let enforce_target = profile == "target" || profile == "both";
@@ -1515,6 +1580,7 @@ relations_expected:
             "both",
             true,
             true,
+            None,
         )
         .expect("validate ok");
         assert_eq!(code, 0);
@@ -1627,6 +1693,7 @@ profiles:
             "both",
             true,
             true,
+            None,
         )
         .expect("strict validate");
         assert_eq!(strict_code, 2);
@@ -1640,6 +1707,7 @@ profiles:
             "both",
             false,
             false,
+            None,
         )
         .expect("report validate");
         assert_eq!(report_code, 0);

--- a/compiler/bcc/src/main.rs
+++ b/compiler/bcc/src/main.rs
@@ -258,6 +258,9 @@ enum ArchAction {
         fail_on_gate: bool,
         #[arg(long, default_value_t = true, action = ArgAction::Set)]
         fail_on_forbidden: bool,
+        /// 导出 bdd seed 可消费的 YAML source 文件到指定目录
+        #[arg(long)]
+        export_bdd_source: Option<String>,
     },
 
     /// 导出 bugfix 可消费的 module_map.json
@@ -445,6 +448,7 @@ fn main() {
                 profile,
                 fail_on_gate,
                 fail_on_forbidden,
+                export_bdd_source,
             } => {
                 arch::validate(
                     &target,
@@ -455,6 +459,7 @@ fn main() {
                     &profile,
                     fail_on_gate,
                     fail_on_forbidden,
+                    export_bdd_source.as_deref(),
                 );
             }
             ArchAction::ExportModuleMap {

--- a/compiler/bcc/tests/cli_arch_bdd.rs
+++ b/compiler/bcc/tests/cli_arch_bdd.rs
@@ -522,3 +522,544 @@ class UserController {
 
     let _ = fs::remove_dir_all(&root);
 }
+
+// ── export-bdd-source 集成测试 ──
+
+/// 构造 validate 测试数据的辅助函数
+fn setup_validate_data(root: &Path) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    let target = root.join("target.yaml");
+    let transition = root.join("transition.yaml");
+    let gates = root.join("gates.yaml");
+    let actual = root.join("actual.json");
+
+    write(
+        &target,
+        r#"version: v3
+kind: target_contract
+intent: target
+source_of_truth: test
+notes: []
+allow_edges:
+  - caller: A
+    callee: B
+forbid_edges:
+  - caller: X
+    callee: Y
+"#,
+    );
+    write(
+        &transition,
+        r#"version: v3
+kind: transition_contract
+base: v3.target
+intent: transition
+notes: []
+temporary_allow_edges: []
+blocked_edges:
+  - caller: X
+    callee: Y
+"#,
+    );
+    write(
+        &gates,
+        r#"version: v3
+kind: verification_gates
+intent: gate
+profiles:
+  transition:
+    max_unexpected_edges_count: 999
+    max_forbidden_edges_count: 999
+    max_forbidden_total_edges: 999
+    max_missing_edges_count: 999
+    max_directed_density_pct: 100
+    max_bidirectional_pair_count: 999
+  target:
+    max_unexpected_edges_count: 999
+    max_forbidden_edges_count: 999
+    max_forbidden_total_edges: 999
+    max_missing_edges_count: 999
+    max_directed_density_pct: 100
+    max_bidirectional_pair_count: 999
+"#,
+    );
+    // A->B: allowed; B->A: unexpected; X->Y: forbidden
+    write(
+        &actual,
+        r#"[
+  {"caller":"A","callee":"B","import_edges":1,"call_edges":0,"total_edges":1},
+  {"caller":"B","callee":"A","import_edges":1,"call_edges":0,"total_edges":1},
+  {"caller":"X","callee":"Y","import_edges":3,"call_edges":0,"total_edges":3}
+]"#,
+    );
+
+    (target, transition, gates, actual)
+}
+
+#[test]
+fn validate_export_bdd_source_generates_yaml() {
+    let root = temp_dir("bcc_validate_bdd_export");
+    let (target, transition, gates, actual) = setup_validate_data(&root);
+    let out = root.join("out");
+    let bdd_dir = root.join("bdd_source");
+
+    let status = Command::new(env!("CARGO_BIN_EXE_bcc"))
+        .args([
+            "arch",
+            "validate",
+            "--target",
+            &target.to_string_lossy(),
+            "--transition",
+            &transition.to_string_lossy(),
+            "--gates",
+            &gates.to_string_lossy(),
+            "--actual",
+            &actual.to_string_lossy(),
+            "--out-dir",
+            &out.to_string_lossy(),
+            "--fail-on-gate",
+            "false",
+            "--fail-on-forbidden",
+            "false",
+            "--export-bdd-source",
+            &bdd_dir.to_string_lossy(),
+        ])
+        .status()
+        .expect("run validate with export-bdd-source");
+    assert!(status.success());
+
+    // bdd_dir 已创建
+    assert!(bdd_dir.exists());
+
+    // forbidden 边 X->Y 生成 YAML（edge_class: blocked）
+    let forbidden_yaml = bdd_dir.join("X_Y.yaml");
+    assert!(forbidden_yaml.exists(), "X_Y.yaml should exist for forbidden edge");
+    let content = fs::read_to_string(&forbidden_yaml).expect("read X_Y.yaml");
+    assert!(content.contains("module: X"));
+    assert!(content.contains("edge_class: blocked"));
+    assert!(content.contains("contract: X -> Y arch violation"));
+    assert!(content.contains("source_file: arch-validate-export"));
+    assert!(content.contains("source_summary:"));
+
+    // unexpected 边 B->A 生成 YAML（edge_class: temporary）
+    let unexpected_yaml = bdd_dir.join("B_A.yaml");
+    assert!(unexpected_yaml.exists(), "B_A.yaml should exist for unexpected edge");
+    let content2 = fs::read_to_string(&unexpected_yaml).expect("read B_A.yaml");
+    assert!(content2.contains("module: B"));
+    assert!(content2.contains("edge_class: temporary"));
+    assert!(content2.contains("source_file: arch-validate-export"));
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn validate_without_export_flag_unchanged() {
+    let root = temp_dir("bcc_validate_no_export");
+    let (target, transition, gates, actual) = setup_validate_data(&root);
+    let out = root.join("out");
+
+    let status = Command::new(env!("CARGO_BIN_EXE_bcc"))
+        .args([
+            "arch",
+            "validate",
+            "--target",
+            &target.to_string_lossy(),
+            "--transition",
+            &transition.to_string_lossy(),
+            "--gates",
+            &gates.to_string_lossy(),
+            "--actual",
+            &actual.to_string_lossy(),
+            "--out-dir",
+            &out.to_string_lossy(),
+            "--fail-on-gate",
+            "false",
+            "--fail-on-forbidden",
+            "false",
+        ])
+        .status()
+        .expect("run validate without export flag");
+    assert!(status.success());
+
+    // 标准输出文件正常
+    assert!(out.join("summary.json").exists());
+    assert!(out.join("scenario-validation.tsv").exists());
+    assert!(out.join("gate-evaluation.tsv").exists());
+    assert!(out.join("v3-validation-report.md").exists());
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn validate_export_empty_violations() {
+    let root = temp_dir("bcc_validate_empty_export");
+    let target = root.join("target.yaml");
+    let transition = root.join("transition.yaml");
+    let gates = root.join("gates.yaml");
+    let actual = root.join("actual.json");
+    let out = root.join("out");
+    let bdd_dir = root.join("bdd_empty");
+
+    write(
+        &target,
+        r#"version: v3
+kind: target_contract
+intent: target
+source_of_truth: test
+notes: []
+allow_edges:
+  - caller: A
+    callee: B
+forbid_edges: []
+"#,
+    );
+    write(
+        &transition,
+        r#"version: v3
+kind: transition_contract
+base: v3.target
+intent: transition
+notes: []
+temporary_allow_edges: []
+blocked_edges: []
+"#,
+    );
+    write(
+        &gates,
+        r#"version: v3
+kind: verification_gates
+intent: gate
+profiles:
+  transition:
+    max_unexpected_edges_count: 999
+    max_forbidden_edges_count: 999
+    max_forbidden_total_edges: 999
+    max_missing_edges_count: 999
+    max_directed_density_pct: 100
+    max_bidirectional_pair_count: 999
+  target:
+    max_unexpected_edges_count: 999
+    max_forbidden_edges_count: 999
+    max_forbidden_total_edges: 999
+    max_missing_edges_count: 999
+    max_directed_density_pct: 100
+    max_bidirectional_pair_count: 999
+"#,
+    );
+    // 只有 allow 内的边，无违规
+    write(
+        &actual,
+        r#"[
+  {"caller":"A","callee":"B","import_edges":1,"call_edges":0,"total_edges":1}
+]"#,
+    );
+
+    let status = Command::new(env!("CARGO_BIN_EXE_bcc"))
+        .args([
+            "arch",
+            "validate",
+            "--target",
+            &target.to_string_lossy(),
+            "--transition",
+            &transition.to_string_lossy(),
+            "--gates",
+            &gates.to_string_lossy(),
+            "--actual",
+            &actual.to_string_lossy(),
+            "--out-dir",
+            &out.to_string_lossy(),
+            "--fail-on-gate",
+            "false",
+            "--fail-on-forbidden",
+            "false",
+            "--export-bdd-source",
+            &bdd_dir.to_string_lossy(),
+        ])
+        .status()
+        .expect("run validate with empty violations");
+    assert!(status.success());
+
+    // bdd_dir 存在但为空（无 YAML 文件）
+    assert!(bdd_dir.exists());
+    let yaml_count = fs::read_dir(&bdd_dir)
+        .expect("read bdd_dir")
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|x| x == "yaml")
+                .unwrap_or(false)
+        })
+        .count();
+    assert_eq!(yaml_count, 0, "no yaml files expected for clean actual");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn validate_truncate_removed_full_output() {
+    let root = temp_dir("bcc_validate_full_output");
+    let target = root.join("target.yaml");
+    let transition = root.join("transition.yaml");
+    let gates = root.join("gates.yaml");
+    let actual = root.join("actual.json");
+    let out = root.join("out");
+    let bdd_dir = root.join("bdd_full");
+
+    // 构造 > 10 条 forbidden 边
+    let mut forbid_edges = String::new();
+    let mut actual_entries = Vec::new();
+    for i in 0..15 {
+        forbid_edges.push_str(&format!(
+            "  - caller: M{}\n    callee: N{}\n",
+            i, i
+        ));
+        actual_entries.push(format!(
+            r#"  {{"caller":"M{}","callee":"N{}","import_edges":{},"call_edges":0,"total_edges":{}}}"#,
+            i, i, i + 1, i + 1
+        ));
+    }
+
+    write(
+        &target,
+        &format!(
+            r#"version: v3
+kind: target_contract
+intent: target
+source_of_truth: test
+notes: []
+allow_edges:
+  - caller: A
+    callee: B
+forbid_edges:
+{}
+"#,
+            forbid_edges
+        ),
+    );
+    write(
+        &transition,
+        &format!(
+            r#"version: v3
+kind: transition_contract
+base: v3.target
+intent: transition
+notes: []
+temporary_allow_edges: []
+blocked_edges:
+{}
+"#,
+            forbid_edges
+        ),
+    );
+    write(
+        &gates,
+        r#"version: v3
+kind: verification_gates
+intent: gate
+profiles:
+  transition:
+    max_unexpected_edges_count: 999
+    max_forbidden_edges_count: 999
+    max_forbidden_total_edges: 999
+    max_missing_edges_count: 999
+    max_directed_density_pct: 100
+    max_bidirectional_pair_count: 999
+  target:
+    max_unexpected_edges_count: 999
+    max_forbidden_edges_count: 999
+    max_forbidden_total_edges: 999
+    max_missing_edges_count: 999
+    max_directed_density_pct: 100
+    max_bidirectional_pair_count: 999
+"#,
+    );
+    write(
+        &actual,
+        &format!("[\n{}\n]", actual_entries.join(",\n")),
+    );
+
+    let status = Command::new(env!("CARGO_BIN_EXE_bcc"))
+        .args([
+            "arch",
+            "validate",
+            "--target",
+            &target.to_string_lossy(),
+            "--transition",
+            &transition.to_string_lossy(),
+            "--gates",
+            &gates.to_string_lossy(),
+            "--actual",
+            &actual.to_string_lossy(),
+            "--out-dir",
+            &out.to_string_lossy(),
+            "--fail-on-gate",
+            "false",
+            "--fail-on-forbidden",
+            "false",
+            "--export-bdd-source",
+            &bdd_dir.to_string_lossy(),
+        ])
+        .status()
+        .expect("run validate full output");
+    assert!(status.success());
+
+    // 验证输出 YAML 文件数 > 10（truncate 已移除）
+    let yaml_count = fs::read_dir(&bdd_dir)
+        .expect("read bdd_dir")
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|x| x == "yaml")
+                .unwrap_or(false)
+        })
+        .count();
+    assert!(
+        yaml_count > 10,
+        "expected > 10 yaml files, got {}",
+        yaml_count
+    );
+
+    // 验证 markdown 报告中包含 "showing top 20 of" 标注
+    let report = fs::read_to_string(out.join("v3-validation-report.md"))
+        .expect("read report");
+    assert!(
+        report.contains("showing top 20 of"),
+        "report should contain 'showing top 20 of' annotation"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn validate_export_then_bdd_seed_e2e() {
+    // 端到端：validate --export-bdd-source 输出 YAML → bdd seed --source 消费
+    let root = temp_dir("bcc_validate_bdd_e2e");
+    let (target, transition, gates, actual) = setup_validate_data(&root);
+    let validate_out = root.join("validate_out");
+    let bdd_source = root.join("bdd_source");
+    let bdd_output = root.join("bdd_output");
+
+    // 第一步：validate --export-bdd-source
+    let validate_status = Command::new(env!("CARGO_BIN_EXE_bcc"))
+        .args([
+            "arch",
+            "validate",
+            "--target",
+            &target.to_string_lossy(),
+            "--transition",
+            &transition.to_string_lossy(),
+            "--gates",
+            &gates.to_string_lossy(),
+            "--actual",
+            &actual.to_string_lossy(),
+            "--out-dir",
+            &validate_out.to_string_lossy(),
+            "--fail-on-gate",
+            "false",
+            "--fail-on-forbidden",
+            "false",
+            "--export-bdd-source",
+            &bdd_source.to_string_lossy(),
+        ])
+        .status()
+        .expect("run validate");
+    assert!(validate_status.success());
+
+    // 确认 bdd_source 目录有 YAML 文件（X_Y.yaml + B_A.yaml）
+    let yaml_count = fs::read_dir(&bdd_source)
+        .expect("read bdd_source")
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|x| x == "yaml")
+                .unwrap_or(false)
+        })
+        .count();
+    assert!(yaml_count >= 2, "expected >= 2 yaml files, got {}", yaml_count);
+
+    // 第二步：bdd seed --source <bdd_source> --step organize --force
+    let seed_status = Command::new(env!("CARGO_BIN_EXE_bcc"))
+        .args([
+            "bdd",
+            "seed",
+            "--source",
+            &bdd_source.to_string_lossy(),
+            "--output",
+            &bdd_output.to_string_lossy(),
+            "--step",
+            "organize",
+            "--edge-class",
+            "all",
+            "--force",
+        ])
+        .status()
+        .expect("run bdd seed");
+    assert!(seed_status.success());
+
+    // 验证 bdd seed 输出结构
+    assert!(bdd_output.join("contexts").exists(), "contexts dir should exist");
+    assert!(bdd_output.join("scenarios").exists(), "scenarios dir should exist");
+    assert!(bdd_output.join("features").exists(), "features dir should exist");
+    assert!(bdd_output.join("coverage.md").exists(), "coverage.md should exist");
+
+    // 验证 context JSON 被正确生成（X_Y.yaml → module=X, B_A.yaml → module=B）
+    let contexts_dir = bdd_output.join("contexts");
+    let context_files: Vec<_> = fs::read_dir(&contexts_dir)
+        .expect("read contexts")
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|x| x == "json")
+                .unwrap_or(false)
+        })
+        .collect();
+    assert!(
+        context_files.len() >= 2,
+        "expected >= 2 context json files, got {}",
+        context_files.len()
+    );
+
+    // 验证 context JSON 中包含正确的 module（从 YAML 的 module 字段读取）
+    let mut found_module_x = false;
+    let mut found_module_b = false;
+    for entry in &context_files {
+        let raw = fs::read_to_string(entry.path()).expect("read context json");
+        if raw.contains("\"module\":\"X\"") || raw.contains("\"module\": \"X\"") {
+            found_module_x = true;
+        }
+        if raw.contains("\"module\":\"B\"") || raw.contains("\"module\": \"B\"") {
+            found_module_b = true;
+        }
+    }
+    assert!(found_module_x, "should have a context with module=X (from X_Y.yaml)");
+    assert!(found_module_b, "should have a context with module=B (from B_A.yaml)");
+
+    // 验证 coverage.md 包含模块名
+    let coverage = fs::read_to_string(bdd_output.join("coverage.md")).expect("read coverage");
+    assert!(coverage.contains("| X |") || coverage.contains("| x |"),
+        "coverage should mention module X");
+    assert!(coverage.contains("| B |") || coverage.contains("| b |"),
+        "coverage should mention module B");
+
+    // 验证 features 目录下生成了 DSL 文件
+    let feature_files: Vec<_> = fs::read_dir(bdd_output.join("features"))
+        .expect("read features")
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|x| x == "dsl")
+                .unwrap_or(false)
+        })
+        .collect();
+    assert!(
+        feature_files.len() >= 2,
+        "expected >= 2 feature dsl files, got {}",
+        feature_files.len()
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
## Summary

- 移除 `evaluate_scenario` 中的 `truncate(10)`，`EvalResult` 保留全量 forbidden/unexpected 边数据
- `arch validate` 新增 `--export-bdd-source <dir>` 参数，将 transition 阶段的违规边导出为 bdd seed 可消费的 YAML source 文件（forbidden → `blocked`，unexpected → `temporary`）
- markdown 报告渲染改为显示 top 20 并标注总数（`showing top 20 of N`）
- YAML 输出包含完整的 `module`/`contract`/`edge_class`/`source_file`/`source_summary` 字段，与 `SeedContext` 结构对齐

Closes #6

## Test plan

- [x] `validate_export_bdd_source_generates_yaml` — forbidden 和 unexpected 边均正确生成 YAML，字段内容验证
- [x] `validate_without_export_flag_unchanged` — 不加 flag 时原有输出不受影响
- [x] `validate_export_empty_violations` — 零违规时 bdd 目录为空
- [x] `validate_truncate_removed_full_output` — 15 条 forbidden 边全量输出（>10），markdown 报告包含 top 20 标注
- [x] `validate_export_then_bdd_seed_e2e` — 端到端验证：validate 输出 YAML → bdd seed 消费 → contexts/scenarios/features/coverage.md 全部生成
- [x] 已有 92 个单元测试 + 17 个 bugfix 集成测试无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)