### PR TITLE
fix: PR #9 review 修复

### DIFF
--- a/compiler/bcc/src/bugfix.rs
+++ b/compiler/bcc/src/bugfix.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs;
 use std::process::Command;
 use serde::{Deserialize, Serialize};
@@ -602,52 +602,6 @@ fn truncate_str(s: &str, max_chars: usize) -> String {
     }
 }
 
-/// 用 gh api 拉取 issue 详情
-fn fetch_issue(repo: &str, number: u64) -> Option<IssueInfo> {
-    let remote = detect_github_remote(repo)?;
-
-    // 拉取 issue 标题和正文
-    let output = Command::new("gh")
-        .args(["api", &format!("repos/{}/issues/{}", remote, number)])
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        eprintln!("[issue] gh api failed for issue #{}: {}", number,
-            String::from_utf8_lossy(&output.stderr).trim());
-        return None;
-    }
-
-    let issue_json: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
-    let title = issue_json["title"].as_str().unwrap_or("").to_string();
-    let body = truncate_str(issue_json["body"].as_str().unwrap_or(""), 2000);
-
-    // 拉取评论
-    let comments_output = Command::new("gh")
-        .args(["api", &format!("repos/{}/issues/{}/comments", remote, number)])
-        .output()
-        .ok();
-
-    let comments: Vec<String> = comments_output
-        .and_then(|o| {
-            if o.status.success() {
-                serde_json::from_slice::<Vec<serde_json::Value>>(&o.stdout).ok()
-            } else {
-                None
-            }
-        })
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|c| c["body"].as_str().map(|b| truncate_str(b, 2000)))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    eprintln!("[issue] fetched #{}: {} ({} comments)", number, title, comments.len());
-
-    Some(IssueInfo { number, title, body, comments })
-}
-
 // ─── issue 内容增强（PR/Issue 合并）────────────────────────
 
 /// 判断 GitHub API 返回的是否为 PR
@@ -671,7 +625,7 @@ fn find_linked_pr(repo: &str, issue_num: u64) -> Option<u64> {
     let output = Command::new("gh")
         .args([
             "api",
-            &format!("search/issues?q=repo:{}+is:pr+closes:{}&sort=updated&order=desc&per_page=1", remote, issue_num)
+            &format!("search/issues?q=repo:{}+is:pr+%22closes+%23{}%22+in:body&sort=updated&order=desc&per_page=1", remote, issue_num)
         ])
         .output()
         .ok()?;

--- a/compiler/bcc/tests/bugfix_bdd.rs
+++ b/compiler/bcc/tests/bugfix_bdd.rs
@@ -1106,14 +1106,18 @@ fn issue_enrichment_merges_pr_and_issue() {
         return;
     }
 
-    let repo = "/Users/biantaishabi/Cli"; // 本仓库
+    // 从 CARGO_MANIFEST_DIR 动态定位仓库根目录
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let repo_path = Path::new(manifest).parent().unwrap().parent().unwrap();
+    let repo = repo_path.to_str().unwrap();
+    let out = temp_dir("bcc_issue_enrichment");
 
     // 测试 1: PR #4 应该能提取到关联的 Issue #2
     // 注意：这需要真实调用 GitHub API
     let result = Command::new(env!("CARGO_BIN_EXE_bcc"))
         .arg("bugfix")
         .args([
-            repo, "-o", "/tmp/test_issue_8", "-s", "c", "--force",
+            repo, "-o", &out.to_string_lossy(), "-s", "c", "--force",
             "--issue", "4", // 手动指定 PR #4
         ])
         .env("BCC_FORCE_PROMPT_MODE", "1")
@@ -1123,9 +1127,9 @@ fn issue_enrichment_merges_pr_and_issue() {
     if let Ok(output) = result {
         assert!(output.status.success(), "collect should not fail: {}",
             String::from_utf8_lossy(&output.stderr));
-        
+
         // 检查 inventory.json
-        if let Ok(inv_content) = fs::read_to_string("/tmp/test_issue_8/inventory.json") {
+        if let Ok(inv_content) = fs::read_to_string(out.join("inventory.json")) {
             let inv: serde_json::Value = serde_json::from_str(&inv_content).unwrap_or_default();
             if let Some(commits) = inv["commits"].as_array() {
                 if let Some(first) = commits.first() {
@@ -1145,7 +1149,7 @@ fn issue_enrichment_merges_pr_and_issue() {
         }
     }
 
-    let _ = fs::remove_dir_all("/tmp/test_issue_8");
+    let _ = fs::remove_dir_all(&out);
 }
 
 /// 测试 extract_closes_refs 正则匹配（单元测试补充）


### PR DESCRIPTION
## Summary

- 修复 `find_linked_pr` search API 查询语法（`closes:` 不是合法 qualifier，改为搜索 body 文本）
- 删除未使用的 `HashSet` import
- 删除已被 `fetch_enriched_issue` 取代的 `fetch_issue` 死代码
- 集成测试路径从硬编码 `/Users/biantaishabi/Cli` 改为 `CARGO_MANIFEST_DIR` 动态定位

Follow-up for PR #9

## Test plan

- [x] 129 个测试全部通过（100 单元 + 19 bugfix 集成 + 10 arch/bdd 集成）
- [x] `fetch_issue` 未使用的 warning 已消除

🤖 Generated with [Claude Code](https://claude.com/claude-code)