### PR TITLE
fix: bug: bcc extract Elixir 误将字符串内的模块引用识别为依赖 (#75)

### DIFF
--- a/compiler/bcc/src/extract/elixir.rs
+++ b/compiler/bcc/src/extract/elixir.rs
@@ -176,8 +176,9 @@ fn extract_recursive(
             _ => {}
         }
 
-        // 递归子节点
-        if cursor.goto_first_child() {
+        // 字符串类节点不递归子节点，防止文档字符串内的模块名被误识别为依赖
+        let skip_children = matches!(kind, "string" | "quoted_content" | "charlist" | "sigil");
+        if !skip_children && cursor.goto_first_child() {
             extract_recursive(cursor, source, exports, imports, calls,
                             module_doc, declarations, side_effects, pending_spec);
             cursor.goto_parent();
@@ -412,6 +413,55 @@ end
         assert_eq!(behaviour_imports.len(), 2);
         assert!(behaviour_imports.iter().any(|i| i.specifier == "GenServer"));
         assert!(behaviour_imports.iter().any(|i| i.specifier == "Gong.Extension"));
+    }
+
+    #[test]
+    fn test_moduledoc_module_ref_not_extracted_as_call() {
+        let source = r#"
+defmodule Gong do
+  @moduledoc """
+  - `Gong.Compaction` — 上下文压缩
+  - `Gong.Truncate` — 输出截断系统
+  """
+end
+"#;
+        let record = extract(source, "lib/gong.ex");
+        // @moduledoc 中提到的模块不应出现在 calls 中
+        assert!(record.calls.is_empty(),
+            "expected no calls, got: {:?}", record.calls);
+    }
+
+    #[test]
+    fn test_real_call_still_extracted() {
+        let source = r#"
+defmodule MyApp.Worker do
+  @moduledoc "Worker that calls Fake.Module in docs"
+
+  def run do
+    Result.ok()
+    Phoenix.PubSub.broadcast(topic, msg)
+  end
+end
+"#;
+        let record = extract(source, "lib/my_app/worker.ex");
+        let callees: Vec<&str> = record.calls.iter().map(|c| c.callee.as_str()).collect();
+        assert!(callees.contains(&"Result"), "should contain Result, got: {:?}", callees);
+        assert!(callees.contains(&"Phoenix.PubSub"), "should contain Phoenix.PubSub, got: {:?}", callees);
+        // 文档字符串中的 Fake.Module 不应被提取
+        assert!(!callees.contains(&"Fake"), "should not contain Fake from docstring, got: {:?}", callees);
+    }
+
+    #[test]
+    fn test_doc_string_module_ref_not_extracted() {
+        let source = r#"
+defmodule MyApp.Foo do
+  @doc "See `MyApp.Bar` for details"
+  def hello, do: :world
+end
+"#;
+        let record = extract(source, "lib/my_app/foo.ex");
+        let callees: Vec<&str> = record.calls.iter().map(|c| c.callee.as_str()).collect();
+        assert!(!callees.contains(&"MyApp"), "should not contain MyApp.Bar from @doc, got: {:?}", callees);
     }
 
     #[test]


### PR DESCRIPTION
Closes #75

## Summary

## ✅ 最终方案：修复 extract_recursive 跳过字符串节点，防止文档字符串中模块引用被误识别为依赖

### 实现方案

在 extract_recursive 函数的递归入口（第 180 行）前，检查当前节点类型是否为字符串类节点。若为 string、quoted_content、sigil 等字符串节点则跳过子节点递归。tree-sitter-elixir 中字符串相关的节点类型包括：string（普通字符串和 heredoc """）、quoted_content（字符串内容体）、charlist（单引号字符串）、sigil（~s/~S/~r 等 sigil 表达式）。修改位置在 elixir.rs 第 179-184 行，将无条件的 cursor.goto_first_child() 改为条件递归。同时在 unary_operator 分支处理 @moduledoc 后，跳过该节点的子树递归（因为 handle_module_attribute 已经手动提取了需要的内容，不需要再递归进入字符串子节点）。具体实现：在第 180 行前加入 skip 判断，对 string / quoted_content / charlist / sigil 类型的节点不递归子节点。这样 @moduledoc 中的 Gong.Compaction 等模块引用就不会产生 dot 节点的 CallRecord。新增单元测试验证：1) 含 @moduledoc 中模块引用的源码不产生虚假 calls；2) 真实的模块调用仍被正确提取。

### 文件变更

| 路径 | 操作 | 描述 |
|------|------|------|
| `compiler/bcc/src/extract/elixir.rs` | modify | 在 extract_recursive 函数第 179-184 行，递归子节点前增加节点类型检查。将 `if cursor.goto_first_child()` 改为 `let skip = matches!(kind, "string" | "quoted_content" | "charlist" | "sigil"); if !skip && cursor.goto_first_child()`。字符串类节点不再递归，防止文档字符串内的模块名被识别为 dot 调用依赖。 |
| `compiler/bcc/src/extract/elixir.rs` | modify | 在 #[cfg(test)] mod tests 中新增两个测试：(1) test_moduledoc_module_ref_not_extracted_as_call —— 验证 @moduledoc 中提到的模块不会出现在 calls 中；(2) test_real_call_still_extracted —— 验证真实的 Module.function() 调用仍然被正确提取为 CallRecord。 |

### 测试场景

1. **moduledoc 中的模块引用不应被提取为 calls**: 输入 `defmodule Gong do
  @moduledoc """
  - `Gong.Compaction` — 上下文压缩
  - `Gong.Truncate` — 输出截断系统
  """
end` → 预期 `extract() 返回的 FileRecord.calls 为空（不包含 Gong.Compaction、Gong.Truncate 等虚假依赖）`
2. **真实模块调用仍被正确提取**: 输入 `defmodule MyApp.Worker do
  @moduledoc "Worker that calls Fake.Module in docs"

  def run do
    Result.ok()
    Phoenix.PubSub.broadcast(topic, msg)
  end
end` → 预期 `calls 包含 Result 和 Phoenix.PubSub（真实调用），不包含 Fake.Module（文档字符串中的引用）`
3. **@doc 字符串中的模块引用不应被提取**: 输入 `defmodule MyApp.Foo do
  @doc "See `MyApp.Bar` for details"
  def hello, do: :world
end` → 预期 `calls 不包含 MyApp.Bar`
4. **sigil 字符串中的模块引用不应被提取**: 输入 `defmodule MyApp.Foo do
  @routes ~s(MyApp.Router.index)
  def hello, do: :world
end` → 预期 `calls 不包含 MyApp.Router（sigil 字符串内容应被跳过）`


---
*方案已定稿，即将开始实现。*
<!-- PLAN_FILES:[{"path":"compiler/bcc/src/extract/elixir.rs","action":"modify","description":"在 extract_recursive 函数第 179-184 行，递归子节点前增加节点类型检查。将 `if cursor.goto_first_child()` 改为 `let skip = matches!(kind, \"string\" | \"quoted_content\" | \"charlist\" | \"sigil\"); if !skip \u0026\u0026 cursor.goto_first_child()`。字符串类节点不再递归，防止文档字符串内的模块名被识别为 dot 调用依赖。"},{"path":"compiler/bcc/src/extract/elixir.rs","action":"modify","description":"在 #[cfg(test)] mod tests 中新增两个测试：(1) test_moduledoc_module_ref_not_extracted_as_call —— 验证 @moduledoc 中提到的模块不会出现在 calls 中；(2) test_real_call_still_extracted —— 验证真实的 Module.function() 调用仍然被正确提取为 CallRecord。"}] -->