### PR TITLE
fix: niuma 收敛检查使用 AI 的 should_finish 建议

### DIFF
--- a/automation/niuma/pkg/agent/orchestrator.go
+++ b/automation/niuma/pkg/agent/orchestrator.go
@@ -768,6 +768,7 @@ func (o *Orchestrator) updateDiscussionSummary(ctx context.Context, existing *gh
 		Type:     marker.TypeDiscussionSummary,
 		Issue:    o.issueNumber,
 		Revision: rev,
+		Finish:   summary.ShouldFinish,
 	}
 	body := FormatDiscussionSummary(summary, m)
 	return o.github.CreateOrUpdateMarker(ctx, o.issueNumber, m, body)
@@ -825,6 +826,7 @@ func (o *Orchestrator) doMultiProviderDiscussion(ctx context.Context, existing *
 		Type:     marker.TypeDiscussionSummary,
 		Issue:    o.issueNumber,
 		Revision: rev,
+		Finish:   summary.ShouldFinish,
 	}
 	body := FormatDiscussionSummary(summary, m)
 	return o.github.CreateOrUpdateMarker(ctx, o.issueNumber, m, body)

--- a/automation/niuma/pkg/marker/marker.go
+++ b/automation/niuma/pkg/marker/marker.go
@@ -34,7 +34,8 @@ type Marker struct {
 	Type     Type
 	Issue    int
 	Revision int
-	PR       int // 仅 PR_CREATED 使用
+	PR       int  // 仅 PR_CREATED 使用
+	Finish   bool // 仅 DISCUSSION_SUMMARY 使用：AI 建议结束讨论
 }
 
 // markerRe 匹配 <!-- BOT:TYPE key=value key=value ... -->
@@ -73,6 +74,10 @@ func Parse(line string) *Marker {
 		case "pr":
 			if n, err := strconv.Atoi(val); err == nil {
 				m.PR = n
+			}
+		case "finish":
+			if val == "1" || val == "true" {
+				m.Finish = true
 			}
 		}
 	}
@@ -127,6 +132,9 @@ func Render(m *Marker) string {
 	}
 	if m.PR > 0 {
 		parts = append(parts, fmt.Sprintf("pr=%d", m.PR))
+	}
+	if m.Finish {
+		parts = append(parts, "finish=1")
 	}
 
 	return strings.Join(parts, " ") + " -->"

--- a/automation/niuma/pkg/marker/marker_test.go
+++ b/automation/niuma/pkg/marker/marker_test.go
@@ -16,6 +16,7 @@ func TestParse_PlanDraft(t *testing.T) {
 	assert.Equal(t, 42, m.Issue)
 	assert.Equal(t, 3, m.Revision)
 	assert.Equal(t, 0, m.PR)
+	assert.False(t, m.Finish)
 }
 
 func TestParse_PRCreated(t *testing.T) {
@@ -131,4 +132,60 @@ func TestRoundTrip(t *testing.T) {
 	assert.Equal(t, original.Type, parsed.Type)
 	assert.Equal(t, original.Issue, parsed.Issue)
 	assert.Equal(t, original.Revision, parsed.Revision)
+}
+
+// === Finish 字段测试（修复 #77）===
+
+func TestParse_DiscussionSummaryWithFinish(t *testing.T) {
+	m := Parse("<!-- BOT:DISCUSSION_SUMMARY issue=1 rev=2 finish=1 -->")
+	require.NotNil(t, m)
+	assert.Equal(t, TypeDiscussionSummary, m.Type)
+	assert.Equal(t, 1, m.Issue)
+	assert.Equal(t, 2, m.Revision)
+	assert.True(t, m.Finish)
+}
+
+func TestParse_DiscussionSummaryWithoutFinish(t *testing.T) {
+	m := Parse("<!-- BOT:DISCUSSION_SUMMARY issue=1 rev=2 -->")
+	require.NotNil(t, m)
+	assert.Equal(t, TypeDiscussionSummary, m.Type)
+	assert.False(t, m.Finish)
+}
+
+func TestParse_FinishTrue(t *testing.T) {
+	// 测试 finish=1
+	m := Parse("<!-- BOT:DISCUSSION_SUMMARY issue=1 rev=1 finish=1 -->")
+	require.NotNil(t, m)
+	assert.True(t, m.Finish)
+}
+
+func TestParse_FinishFalse(t *testing.T) {
+	// 测试 finish=0 或没有 finish
+	m := Parse("<!-- BOT:DISCUSSION_SUMMARY issue=1 rev=1 finish=0 -->")
+	require.NotNil(t, m)
+	assert.False(t, m.Finish)
+}
+
+func TestRender_WithFinish(t *testing.T) {
+	m := &Marker{Type: TypeDiscussionSummary, Issue: 1, Revision: 2, Finish: true}
+	rendered := Render(m)
+	assert.Equal(t, "<!-- BOT:DISCUSSION_SUMMARY issue=1 rev=2 finish=1 -->", rendered)
+}
+
+func TestRender_WithoutFinish(t *testing.T) {
+	m := &Marker{Type: TypeDiscussionSummary, Issue: 1, Revision: 2, Finish: false}
+	rendered := Render(m)
+	assert.Equal(t, "<!-- BOT:DISCUSSION_SUMMARY issue=1 rev=2 -->", rendered)
+}
+
+func TestRoundTrip_WithFinish(t *testing.T) {
+	original := &Marker{Type: TypeDiscussionSummary, Issue: 7, Revision: 2, Finish: true}
+	rendered := Render(original)
+	parsed := Parse(rendered)
+
+	require.NotNil(t, parsed)
+	assert.Equal(t, original.Type, parsed.Type)
+	assert.Equal(t, original.Issue, parsed.Issue)
+	assert.Equal(t, original.Revision, parsed.Revision)
+	assert.Equal(t, original.Finish, parsed.Finish)
 }

--- a/automation/niuma/pkg/state/convergence.go
+++ b/automation/niuma/pkg/state/convergence.go
@@ -57,6 +57,7 @@ type ConvergenceInput struct {
 	DiscussionSummary *marker.Marker // 可为 nil
 	ConvergeWarning   *marker.Marker // 可为 nil
 	WarningTime       time.Time      // 预警评论的创建时间
+	AIShouldFinish    bool           // AI 建议结束讨论（discussion summary 中的 should_finish）
 }
 
 // Check 纯函数：根据输入数据检查收敛条件
@@ -71,6 +72,11 @@ func (c *ConvergenceChecker) Check(input *ConvergenceInput) ConvergeResult {
 		case "/hold":
 			return NotConverged
 		}
+	}
+
+	// 1. AI 建议收敛：discussion summary 中 should_finish=true
+	if input.AIShouldFinish {
+		return ShouldFinalize
 	}
 
 	// 2. 轮次收敛：讨论汇总更新 ≥ MaxRounds 次
@@ -125,6 +131,7 @@ func (m *Machine) CheckConvergence(ctx context.Context, checker *ConvergenceChec
 	}
 	if summaryMC != nil {
 		input.DiscussionSummary = summaryMC.Marker
+		input.AIShouldFinish = summaryMC.Marker.Finish
 	}
 	if warningMC != nil {
 		input.ConvergeWarning = warningMC.Marker

--- a/automation/niuma/pkg/state/convergence_test.go
+++ b/automation/niuma/pkg/state/convergence_test.go
@@ -175,3 +175,82 @@ func TestConvergence_IgnoresBotComments(t *testing.T) {
 	// 最后一条非 bot 评论是 5 分钟前，不到 10 分钟
 	assert.Equal(t, NotConverged, checker.Check(input))
 }
+
+// === AI 建议收敛测试（修复 #77）===
+
+func TestConvergence_ShouldFinalize_AISuggestion(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	checker := fixedChecker(now)
+	input := &ConvergenceInput{
+		Comments: []*github.IssueComment{
+			// 只有 bot 评论，没有人类评论
+			makeComment("<!-- BOT:PLAN_DRAFT issue=1 rev=1 -->\n方案草案", now.Add(-10*time.Minute)),
+		},
+		DiscussionSummary: &marker.Marker{
+			Type:     marker.TypeDiscussionSummary,
+			Issue:    1,
+			Revision: 2,
+			Finish:   true, // AI 建议结束讨论
+		},
+		AIShouldFinish: true,
+	}
+	// AI 建议应该触发定稿，即使没有人类评论
+	assert.Equal(t, ShouldFinalize, checker.Check(input))
+}
+
+func TestConvergence_HoldOverridesAI(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	checker := fixedChecker(now)
+	input := &ConvergenceInput{
+		Comments: []*github.IssueComment{
+			makeComment("/hold", now.Add(-1*time.Minute)),
+		},
+		DiscussionSummary: &marker.Marker{
+			Type:     marker.TypeDiscussionSummary,
+			Issue:    1,
+			Revision: 2,
+			Finish:   true,
+		},
+		AIShouldFinish: true,
+	}
+	// /hold 命令优先于 AI 建议
+	assert.Equal(t, NotConverged, checker.Check(input))
+}
+
+func TestConvergence_AIFalse_FallsThrough(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	checker := fixedChecker(now)
+	input := &ConvergenceInput{
+		Comments: []*github.IssueComment{
+			makeComment("人的评论", now.Add(-5*time.Minute)),
+		},
+		DiscussionSummary: &marker.Marker{
+			Type:     marker.TypeDiscussionSummary,
+			Issue:    1,
+			Revision: 2,
+			Finish:   false, // AI 不建议结束
+		},
+		AIShouldFinish: false,
+	}
+	// AI 不建议结束，继续其他收敛检查（静默时间不够）
+	assert.Equal(t, NotConverged, checker.Check(input))
+}
+
+func TestConvergence_AIFalse_WithRounds(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	checker := fixedChecker(now)
+	input := &ConvergenceInput{
+		Comments: []*github.IssueComment{
+			makeComment("人的评论", now.Add(-1*time.Minute)),
+		},
+		DiscussionSummary: &marker.Marker{
+			Type:     marker.TypeDiscussionSummary,
+			Issue:    1,
+			Revision: 5, // 达到轮次阈值
+			Finish:   false,
+		},
+		AIShouldFinish: false,
+	}
+	// AI 不建议结束，但轮次达到阈值，应该定稿
+	assert.Equal(t, ShouldFinalize, checker.Check(input))
+}


### PR DESCRIPTION
## 问题

niuma 在自动模式下，当 issue 只有 bot 评论、没有人类评论时，会卡在 needs-discussion 状态无法定稿。

## 修复

- 在 ConvergenceInput 中添加 AIShouldFinish 字段
- 在 Check() 中添加 AI 建议收敛检查（优先级：命令 > AI > 轮次 > 静默）
- 在 Marker 中添加 Finish 字段，支持解析和渲染 finish=1
- 在 orchestrator 中设置 summary.ShouldFinish 到 marker.Finish

## 测试

新增测试：
- TestConvergence_ShouldFinalize_AISuggestion
- TestConvergence_HoldOverridesAI
- TestConvergence_AIFalse_FallsThrough
- TestConvergence_AIFalse_WithRounds
- TestParse_DiscussionSummaryWithFinish
- TestRender_WithFinish
- TestRoundTrip_WithFinish

全量测试通过。

Closes #77