### PR TITLE
fix: PR96 验收修复与图谱验证增强 (#121)

### DIFF
--- a/compiler/bcc/src/graph/arch.rs
+++ b/compiler/bcc/src/graph/arch.rs
@@ -66,13 +66,14 @@ impl ArchValidator {
             }
         }
 
+        let violation_count = violations.len();
         Ok(ArchValidationResult {
             passed: violations.is_empty(),
             violations,
             stats: ValidationStats {
                 total_functions,
                 checked_deps,
-                violation_count: 0, // 会在下面更新
+                violation_count,
             },
         })
     }
@@ -179,11 +180,9 @@ impl ArchValidator {
         }
     }
 
-    /// 获取所有函数（通过模块查询）
-    fn get_all_functions(&self, _store: &dyn CodeGraphStore) -> Vec<FunctionRecord> {
-        // 简化实现：返回空列表，实际应该遍历所有模块
-        // 这里依赖调用者提供函数列表
-        vec![]
+    /// 获取所有函数
+    fn get_all_functions(&self, store: &dyn CodeGraphStore) -> Vec<FunctionRecord> {
+        store.list_functions()
     }
 
     /// 验证指定函数的架构合规性

--- a/compiler/bcc/src/graph/cli.rs
+++ b/compiler/bcc/src/graph/cli.rs
@@ -6,7 +6,7 @@ use crate::graph::sqlite::GraphStoreManager;
 use crate::graph::store::{CodeGraphStore, GraphStoreInsert};
 use crate::graph::types::{CallEdge, CallType, FunctionRecord, Repository, SearchInclude, ModuleRecord, ModuleDepEdge, DepType};
 use chrono::Utc;
-use std::path::PathBuf;
+use std::collections::BTreeSet;
 
 /// 查询类型
 #[derive(Debug, Clone)]
@@ -46,12 +46,14 @@ pub fn build_index(
     let manager = GraphStoreManager::default()?;
     let store = manager.get_store(repo_id)?;
     
+    let languages = detect_snapshot_languages(&snapshot);
+
     // 创建/更新仓库信息
     let repo = Repository {
         id: repo_id.to_string(),
         name: repo_name.to_string(),
         root_path: root_path.to_string(),
-        languages: "python".to_string(), // 从 extract 输出检测
+        languages,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     };
@@ -92,7 +94,7 @@ pub fn build_index(
             exports_count: record.exports_count,
             imports_count: record.imports_count,
             loc_lines: record.loc_lines,
-            language: "typescript".to_string(),
+            language: detect_language_from_path(&record.sourcePath),
         };
         
         GraphStoreInsert::insert_module(&store, &module)?;
@@ -107,7 +109,7 @@ pub fn build_index(
             name: "__file__".to_string(),
             file_path: record.sourcePath.clone(),
             module: extract_module(&record.sourcePath),
-            language: "typescript".to_string(),
+            language: detect_language_from_path(&record.sourcePath),
             start_line: 1,
             end_line: record.loc_lines,
             signature: format!("module: {} ({} lines)", record.sourcePath, record.loc_lines),
@@ -198,6 +200,39 @@ fn extract_module(file_path: &str) -> String {
         .and_then(|n| n.to_str())
         .unwrap_or("root")
         .to_string()
+}
+
+fn detect_snapshot_languages(snapshot: &crate::extract::AstSnapshot) -> String {
+    let mut langs = BTreeSet::new();
+    for record in &snapshot.records {
+        langs.insert(detect_language_from_path(&record.sourcePath));
+    }
+    if langs.is_empty() {
+        "unknown".to_string()
+    } else {
+        langs.into_iter().collect::<Vec<_>>().join(",")
+    }
+}
+
+fn detect_language_from_path(file_path: &str) -> String {
+    let path = file_path.to_ascii_lowercase();
+    if path.ends_with(".py") {
+        "python".to_string()
+    } else if path.ends_with(".ts") || path.ends_with(".tsx") {
+        "typescript".to_string()
+    } else if path.ends_with(".js") || path.ends_with(".jsx") {
+        "javascript".to_string()
+    } else if path.ends_with(".rs") {
+        "rust".to_string()
+    } else if path.ends_with(".php") {
+        "php".to_string()
+    } else if path.ends_with(".ex") || path.ends_with(".exs") {
+        "elixir".to_string()
+    } else if path.ends_with(".go") {
+        "go".to_string()
+    } else {
+        "unknown".to_string()
+    }
 }
 
 /// graph-index query 命令
@@ -486,8 +521,8 @@ pub fn validate_arch(
     println!("Validating architecture for repo: {}", repo_id);
     println!("Target matrix: {}", target_path);
     
-    // 执行验证
-    let result = validator.validate_function(&store, "")?;
+    // 执行仓库级验证
+    let result = validator.validate(&store)?;
     
     println!("\nValidation result: {}", if result.passed { "PASSED" } else { "FAILED" });
     println!("Total functions: {}", result.stats.total_functions);

--- a/compiler/bcc/src/graph/sqlite.rs
+++ b/compiler/bcc/src/graph/sqlite.rs
@@ -6,9 +6,7 @@ use crate::graph::store::{CodeGraphStore, CommitInfo, GraphStoreInsert};
 use crate::graph::types::*;
 use chrono::Utc;
 use rusqlite::{params, Connection, OptionalExtension};
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
 
 /// SQLite 图存储实现
 pub struct SqliteGraphStore {
@@ -287,6 +285,22 @@ impl CodeGraphStore for SqliteGraphStore {
         };
 
         let rows = match stmt.query_map(params![name], Self::parse_function_row) {
+            Ok(rows) => rows,
+            Err(_) => return vec![],
+        };
+
+        rows.filter_map(|r| r.ok()).collect()
+    }
+
+    fn list_functions(&self) -> Vec<FunctionRecord> {
+        let mut stmt = match self.conn.prepare(
+            "SELECT * FROM functions ORDER BY file_path, start_line"
+        ) {
+            Ok(s) => s,
+            Err(_) => return vec![],
+        };
+
+        let rows = match stmt.query_map([], Self::parse_function_row) {
             Ok(rows) => rows,
             Err(_) => return vec![],
         };
@@ -633,7 +647,7 @@ impl CodeGraphStore for SqliteGraphStore {
         self.check_depth(depth)?;
         
         let mut functions = Vec::new();
-        let mut classes = Vec::new();
+        let classes = Vec::new();
         let mut seen_ids = std::collections::HashSet::new();
         
         // 获取查询函数的基本信息

--- a/compiler/bcc/src/graph/store.rs
+++ b/compiler/bcc/src/graph/store.rs
@@ -39,6 +39,9 @@ pub trait CodeGraphStore {
     /// 按名称查询函数
     fn find_by_name(&self, name: &str) -> Vec<FunctionRecord>;
 
+    /// 获取仓库内所有函数
+    fn list_functions(&self) -> Vec<FunctionRecord>;
+
     /// 查找调用者（支持深度）
     fn find_callers(&self, function_id: &str, depth: usize) -> Result<Vec<FunctionRecord>>;
 

--- a/compiler/bcc/tests/graph_e2e.rs
+++ b/compiler/bcc/tests/graph_e2e.rs
@@ -2,8 +2,10 @@
 //!
 //! 运行条件: 手动触发（通过 workflow_dispatch）
 //! 环境变量: E2E_TEST_REPO=/path/to/openclaw
+//! 可选环境变量: BCC_BIN=/path/to/bcc
+//! 手动执行: E2E_TEST_REPO=/path/to/repo cargo test -p bcc --test graph_e2e <case> -- --ignored --nocapture
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// 获取测试仓库路径
@@ -11,23 +13,34 @@ fn get_test_repo() -> Option<PathBuf> {
     std::env::var("E2E_TEST_REPO").ok().map(PathBuf::from)
 }
 
+/// 定位 workspace 根目录（默认从 compiler/bcc 回溯到仓库根）
+fn workspace_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .join("../..")
+        .canonicalize()
+        .unwrap_or(manifest_dir)
+}
+
 /// 运行 bcc 命令
 fn run_bcc(args: &[&str]) -> Result<String, String> {
-    // 尝试使用 release 二进制，如果不存在则使用 cargo run
-    let bcc_path = "/Users/biantaishabi/Cli-graph-68/target/release/bcc";
-    
-    let output = if std::path::Path::new(bcc_path).exists() {
-        Command::new(bcc_path)
+    // 优先使用显式指定的二进制路径（便于 CI/本地复用）
+    let output = if let Ok(bcc_bin) = std::env::var("BCC_BIN") {
+        if !Path::new(&bcc_bin).exists() {
+            return Err(format!("BCC_BIN does not exist: {}", bcc_bin));
+        }
+        Command::new(&bcc_bin)
             .args(args)
             .output()
-            .map_err(|e| format!("Failed to run bcc binary: {}", e))?
+            .map_err(|e| format!("Failed to run bcc binary (BCC_BIN={}): {}", bcc_bin, e))?
     } else {
+        // 回退到当前仓库执行 cargo run
         Command::new("cargo")
             .args(&["run", "--release", "--bin", "bcc", "--"])
             .args(args)
-            .current_dir("/Users/biantaishabi/Cli-graph-68")
+            .current_dir(workspace_root())
             .output()
-            .map_err(|e| format!("Failed to run cargo: {}", e))?
+            .map_err(|e| format!("Failed to run cargo in workspace root: {}", e))?
     };
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();

--- a/compiler/bcc/tests/graph_integration.rs
+++ b/compiler/bcc/tests/graph_integration.rs
@@ -1,9 +1,10 @@
 //! Graph 模块集成测试
 
 use bcc::graph::error::GraphError;
+use bcc::graph::arch::ArchValidator;
 use bcc::graph::sqlite::GraphStoreManager;
 use bcc::graph::store::{CodeGraphStore, GraphStoreInsert};
-use bcc::graph::types::{FunctionRecord, Repository, ModuleRecord, ModuleDepEdge, DepType};
+use bcc::graph::types::{FunctionRecord, Repository, ModuleRecord, ModuleDepEdge, DepType, CallEdge, CallType};
 use chrono::Utc;
 use std::thread;
 
@@ -458,4 +459,71 @@ fn test_module_depth_limit() {
     // 测试 dependents 深度限制
     let result = store.find_module_dependents("src/test.ts", 101);
     assert!(matches!(result, Err(GraphError::DepthLimitExceeded(100))));
+}
+
+#[test]
+fn test_arch_validation_violation_count_matches_len() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let manager = GraphStoreManager::new(temp_dir.path()).unwrap();
+    let store = manager.get_store("arch-validate").unwrap();
+
+    let api_func = FunctionRecord {
+        id: "app/Controllers/UserController.php#create#10".to_string(),
+        name: "create".to_string(),
+        file_path: "app/Controllers/UserController.php".to_string(),
+        module: "Controllers".to_string(),
+        language: "php".to_string(),
+        start_line: 10,
+        end_line: 20,
+        signature: "public function create()".to_string(),
+        content_hash: "hash-api".to_string(),
+        indexed_at: Utc::now(),
+    };
+    let dao_func = FunctionRecord {
+        id: "app/Models/UserModel.php#insert#5".to_string(),
+        name: "insert".to_string(),
+        file_path: "app/Models/UserModel.php".to_string(),
+        module: "Models".to_string(),
+        language: "php".to_string(),
+        start_line: 5,
+        end_line: 12,
+        signature: "public function insert()".to_string(),
+        content_hash: "hash-dao".to_string(),
+        indexed_at: Utc::now(),
+    };
+    GraphStoreInsert::insert_function(&store, &api_func).unwrap();
+    GraphStoreInsert::insert_function(&store, &dao_func).unwrap();
+    GraphStoreInsert::insert_call_edge(&store, &CallEdge {
+        caller_id: api_func.id.clone(),
+        callee_id: dao_func.id.clone(),
+        call_type: CallType::Direct,
+        file_path: Some("app/Controllers/UserController.php".to_string()),
+        line_number: Some(12),
+    }).unwrap();
+
+    let matrix_file = temp_dir.path().join("target-matrix.yaml");
+    std::fs::write(&matrix_file, r#"
+layers:
+  - name: api
+    patterns:
+      - "*/Controllers/*"
+  - name: service
+    patterns:
+      - "*/Services/*"
+  - name: dao
+    patterns:
+      - "*/Models/*"
+allowed_deps:
+  - from: api
+    to: service
+  - from: service
+    to: dao
+"#).unwrap();
+
+    let validator = ArchValidator::from_yaml(&matrix_file).unwrap();
+    let result = validator.validate(&store).unwrap();
+
+    assert_eq!(result.violations.len(), result.stats.violation_count);
+    assert_eq!(result.stats.violation_count, 1);
+    assert!(!result.passed);
 }


### PR DESCRIPTION
## Summary
- 修复 `graph validate-arch` 走错入口，改为仓库级验证
- 修复 `violation_count` 统计，确保与 `violations.len()` 一致
- 增强 `ArchValidator` 全量函数扫描能力（新增 `list_functions`）
- 移除 `graph_e2e` 本机绝对路径依赖，支持 `BCC_BIN` + 仓库内 `cargo run`
- 改进 `graph build` 语言元数据识别（仓库/模块/函数按后缀推断）
- 补充集成测试覆盖上述统计与验证路径

## Test plan
- `cargo test -p bcc --test graph_integration -- --nocapture`
- `cargo test -p bcc --test graph_bdd --features bdd`
- `E2E_TEST_REPO=/home/wangbo/document/Cli cargo test -p bcc --test graph_e2e e2e_full_workflow_openclaw -- --ignored`

Closes #121
