### PR TITLE
fix(niuma): 兼容 taskctl 扁平命令并修复 control run

### DIFF
--- a/automation/niuma/pkg/control/controller_test.go
+++ b/automation/niuma/pkg/control/controller_test.go
@@ -304,5 +304,5 @@ func TestFormatStatus(t *testing.T) {
 	assert.Contains(t, output, "#40")
 	assert.Contains(t, output, "#41")
 	assert.Contains(t, output, "completed")
-	assert.Contains(t, output, "in_progress")
+	assert.Contains(t, output, string(TaskStatusInProgress))
 }

--- a/automation/niuma/pkg/control/taskctl.go
+++ b/automation/niuma/pkg/control/taskctl.go
@@ -65,15 +65,25 @@ func discoverBin(configBin, repoDir string) (string, error) {
 
 // Create 创建新任务
 func (c *TaskCtlClient) Create(subject, desc string, meta map[string]string) (*Task, error) {
-	args := []string{"task", "create", "--subject", subject}
-	if desc != "" {
-		args = append(args, "--desc", desc)
+	description := strings.TrimSpace(desc)
+	if description == "" {
+		description = subject
 	}
-	args = append(args, "--store", c.StorePath)
 
-	// 以 key=value 格式传递 metadata
-	for k, v := range meta {
-		args = append(args, "--meta", fmt.Sprintf("%s=%s", k, v))
+	args := []string{
+		"create",
+		"--store", c.StorePath,
+		"--subject", subject,
+		"--description", description,
+	}
+
+	// 新版 taskctl 使用 JSON 对象传递 metadata。
+	if len(meta) > 0 {
+		metadataJSON, err := json.Marshal(meta)
+		if err != nil {
+			return nil, fmt.Errorf("编码 metadata 失败: %w", err)
+		}
+		args = append(args, "--metadata", string(metadataJSON))
 	}
 
 	out, err := c.run(args...)
@@ -85,25 +95,30 @@ func (c *TaskCtlClient) Create(subject, desc string, meta map[string]string) (*T
 	if err := json.Unmarshal([]byte(out), &task); err != nil {
 		return nil, fmt.Errorf("解析任务 JSON 失败: %w\noutput: %s", err, out)
 	}
+	normalizeTask(&task)
 	return &task, nil
 }
 
 // Update 更新任务
 func (c *TaskCtlClient) Update(taskID string, opts UpdateOpts) error {
-	args := []string{"task", "update", taskID, "--store", c.StorePath}
+	args := []string{"update", "--store", c.StorePath, "--task-id", taskID}
 
 	if opts.Status != nil {
-		args = append(args, "--status", string(*opts.Status))
-	}
-	if opts.BlockedBy != nil {
-		for _, dep := range *opts.BlockedBy {
-			args = append(args, "--blocked-by", dep)
+		statusArg, err := toTaskctlStatus(*opts.Status)
+		if err != nil {
+			return fmt.Errorf("更新任务 %s 失败: %w", taskID, err)
 		}
+		args = append(args, "--status", statusArg)
+	}
+	if opts.BlockedBy != nil && len(*opts.BlockedBy) > 0 {
+		args = append(args, "--add-blocked-by", strings.Join(*opts.BlockedBy, ","))
 	}
 	if opts.Metadata != nil {
-		for k, v := range *opts.Metadata {
-			args = append(args, "--meta", fmt.Sprintf("%s=%s", k, v))
+		metadataJSON, err := json.Marshal(*opts.Metadata)
+		if err != nil {
+			return fmt.Errorf("更新任务 %s 失败: 编码 metadata 失败: %w", taskID, err)
 		}
+		args = append(args, "--metadata", string(metadataJSON))
 	}
 
 	_, err := c.run(args...)
@@ -115,7 +130,7 @@ func (c *TaskCtlClient) Update(taskID string, opts UpdateOpts) error {
 
 // Ready 获取所有就绪任务（无 blocked_by 且状态为 pending）
 func (c *TaskCtlClient) Ready() ([]Task, error) {
-	out, err := c.run("task", "ready", "--store", c.StorePath, "--format", "json")
+	out, err := c.run("ready", "--store", c.StorePath)
 	if err != nil {
 		return nil, fmt.Errorf("获取就绪任务失败: %w", err)
 	}
@@ -124,12 +139,13 @@ func (c *TaskCtlClient) Ready() ([]Task, error) {
 	if err := json.Unmarshal([]byte(out), &tasks); err != nil {
 		return nil, fmt.Errorf("解析就绪任务 JSON 失败: %w\noutput: %s", err, out)
 	}
+	normalizeTasks(tasks)
 	return tasks, nil
 }
 
 // Dag 获取 DAG 图
 func (c *TaskCtlClient) Dag() (*DagGraph, error) {
-	out, err := c.run("task", "dag", "--store", c.StorePath, "--format", "json")
+	out, err := c.run("dag", "--store", c.StorePath)
 	if err != nil {
 		return nil, fmt.Errorf("获取 DAG 失败: %w", err)
 	}
@@ -143,9 +159,13 @@ func (c *TaskCtlClient) Dag() (*DagGraph, error) {
 
 // List 列出指定状态的任务（空字符串列出所有）
 func (c *TaskCtlClient) List(status string) ([]Task, error) {
-	args := []string{"task", "list", "--store", c.StorePath, "--format", "json"}
+	args := []string{"list", "--store", c.StorePath}
 	if status != "" {
-		args = append(args, "--status", status)
+		statusArg, err := toTaskctlStatus(TaskStatus(status))
+		if err != nil {
+			return nil, fmt.Errorf("列出任务失败: %w", err)
+		}
+		args = append(args, "--status", statusArg)
 	}
 
 	out, err := c.run(args...)
@@ -157,12 +177,13 @@ func (c *TaskCtlClient) List(status string) ([]Task, error) {
 	if err := json.Unmarshal([]byte(out), &tasks); err != nil {
 		return nil, fmt.Errorf("解析任务列表 JSON 失败: %w\noutput: %s", err, out)
 	}
+	normalizeTasks(tasks)
 	return tasks, nil
 }
 
 // Get 获取单个任务
 func (c *TaskCtlClient) Get(taskID string) (*Task, error) {
-	out, err := c.run("task", "get", taskID, "--store", c.StorePath, "--format", "json")
+	out, err := c.run("get", "--task-id", taskID, "--store", c.StorePath)
 	if err != nil {
 		return nil, fmt.Errorf("获取任务 %s 失败: %w", taskID, err)
 	}
@@ -171,6 +192,7 @@ func (c *TaskCtlClient) Get(taskID string) (*Task, error) {
 	if err := json.Unmarshal([]byte(out), &task); err != nil {
 		return nil, fmt.Errorf("解析任务 JSON 失败: %w\noutput: %s", err, out)
 	}
+	normalizeTask(&task)
 	return &task, nil
 }
 
@@ -198,4 +220,51 @@ func (c *TaskCtlClient) run(args ...string) (string, error) {
 		return "", fmt.Errorf("taskctl %s: %w\noutput: %s", strings.Join(args, " "), err, string(out))
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// normalizeTasks 归一化 taskctl 输出，兼容历史字段值。
+func normalizeTasks(tasks []Task) {
+	for i := range tasks {
+		normalizeTask(&tasks[i])
+	}
+}
+
+// normalizeTask 归一化单个任务结构。
+func normalizeTask(task *Task) {
+	if task.Description == "" && task.Desc != "" {
+		task.Description = task.Desc
+	}
+	task.Status = normalizeTaskStatus(task.Status)
+}
+
+// normalizeTaskStatus 将历史状态值统一到当前约定。
+func normalizeTaskStatus(status TaskStatus) TaskStatus {
+	switch strings.ToLower(string(status)) {
+	case "pending":
+		return TaskStatusPending
+	case "in-progress", "in_progress":
+		return TaskStatusInProgress
+	case "completed":
+		return TaskStatusCompleted
+	case "deleted":
+		return TaskStatusDeleted
+	default:
+		return status
+	}
+}
+
+// toTaskctlStatus 将控制层状态映射为 taskctl CLI 可接受的状态值。
+func toTaskctlStatus(status TaskStatus) (string, error) {
+	switch normalizeTaskStatus(status) {
+	case TaskStatusPending:
+		return "pending", nil
+	case TaskStatusInProgress:
+		return "in-progress", nil
+	case TaskStatusCompleted:
+		return "completed", nil
+	case TaskStatusDeleted:
+		return "deleted", nil
+	default:
+		return "", fmt.Errorf("不支持的 task 状态: %s", status)
+	}
 }

--- a/automation/niuma/pkg/control/taskctl_test.go
+++ b/automation/niuma/pkg/control/taskctl_test.go
@@ -1,8 +1,10 @@
 package control
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -87,4 +89,109 @@ func TestNewTaskCtlClient_CreatesNiumaDir(t *testing.T) {
 	// 验证 .niuma 目录被创建
 	_, err = os.Stat(filepath.Join(tmp, ".niuma"))
 	assert.NoError(t, err)
+}
+
+func TestTaskCtlClientCreate_UsesFlatCommandAndJsonMetadata(t *testing.T) {
+	tmp := t.TempDir()
+	argsFile := filepath.Join(tmp, "args.txt")
+	bin := filepath.Join(tmp, "taskctl")
+	script := `#!/usr/bin/env bash
+set -e
+: > "$ARGS_FILE"
+for arg in "$@"; do
+  printf '%s\n' "$arg" >> "$ARGS_FILE"
+done
+cat <<'JSON'
+{"id":"t1","subject":"demo","description":"desc","status":"pending","blocked_by":[],"metadata":{"issue_num":"42"}}
+JSON
+`
+	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
+	t.Setenv("ARGS_FILE", argsFile)
+
+	client := &TaskCtlClient{BinPath: bin, StorePath: filepath.Join(tmp, "tasks.json")}
+	task, err := client.Create("demo", "desc", map[string]string{"issue_num": "42"})
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	assert.Equal(t, TaskStatusPending, task.Status)
+
+	content, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	args := strings.Fields(string(content))
+
+	require.NotEmpty(t, args)
+	assert.Equal(t, "create", args[0])
+	assert.NotContains(t, args, "task")
+	assert.Contains(t, args, "--description")
+	assert.Contains(t, args, "--metadata")
+
+	metadataArg := ""
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--metadata" {
+			metadataArg = args[i+1]
+			break
+		}
+	}
+	require.NotEmpty(t, metadataArg)
+
+	var metadata map[string]string
+	require.NoError(t, json.Unmarshal([]byte(metadataArg), &metadata))
+	assert.Equal(t, "42", metadata["issue_num"])
+}
+
+func TestTaskCtlClientUpdate_MapsStatusAndBlockedBy(t *testing.T) {
+	tmp := t.TempDir()
+	argsFile := filepath.Join(tmp, "args.txt")
+	bin := filepath.Join(tmp, "taskctl")
+	script := `#!/usr/bin/env bash
+set -e
+: > "$ARGS_FILE"
+for arg in "$@"; do
+  printf '%s\n' "$arg" >> "$ARGS_FILE"
+done
+echo "{}"
+`
+	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
+	t.Setenv("ARGS_FILE", argsFile)
+
+	client := &TaskCtlClient{BinPath: bin, StorePath: filepath.Join(tmp, "tasks.json")}
+	status := TaskStatus("in_progress") // 验证旧状态值可映射到新版 in-progress
+	blockedBy := []string{"t1", "t2"}
+	metadata := map[string]string{"k": "v"}
+	err := client.Update("task-9", UpdateOpts{
+		Status:    &status,
+		BlockedBy: &blockedBy,
+		Metadata:  &metadata,
+	})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	args := strings.Fields(string(content))
+
+	assert.Equal(t, "update", args[0])
+	assert.Contains(t, args, "--task-id")
+	assert.Contains(t, args, "task-9")
+	assert.Contains(t, args, "--status")
+	assert.Contains(t, args, "in-progress")
+	assert.Contains(t, args, "--add-blocked-by")
+	assert.Contains(t, args, "t1,t2")
+}
+
+func TestTaskCtlClientList_NormalizesLegacyStatus(t *testing.T) {
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "taskctl")
+	script := `#!/usr/bin/env bash
+set -e
+cat <<'JSON'
+[{"id":"t1","subject":"demo","description":"d","status":"in_progress","blocked_by":[],"metadata":{"issue_num":"42"}}]
+JSON
+`
+	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
+
+	client := &TaskCtlClient{BinPath: bin, StorePath: filepath.Join(tmp, "tasks.json")}
+	tasks, err := client.List("")
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, TaskStatusInProgress, tasks[0].Status)
+	assert.Equal(t, "d", tasks[0].Description)
 }

--- a/automation/niuma/pkg/control/types.go
+++ b/automation/niuma/pkg/control/types.go
@@ -9,20 +9,24 @@ type TaskStatus string
 
 const (
 	TaskStatusPending    TaskStatus = "pending"
-	TaskStatusInProgress TaskStatus = "in_progress"
+	TaskStatusInProgress TaskStatus = "in-progress"
 	TaskStatusCompleted  TaskStatus = "completed"
+	TaskStatusDeleted    TaskStatus = "deleted"
 	TaskStatusBlocked    TaskStatus = "blocked"
 	TaskStatusFailed     TaskStatus = "failed"
 )
 
 // Task 表示一个受 taskctl 管理的任务
 type Task struct {
-	ID        string            `json:"id"`
-	Subject   string            `json:"subject"`
-	Desc      string            `json:"desc,omitempty"`
-	Status    TaskStatus        `json:"status"`
-	BlockedBy []string          `json:"blocked_by,omitempty"`
-	Metadata  map[string]string `json:"metadata,omitempty"`
+	ID          string            `json:"id"`
+	Subject     string            `json:"subject"`
+	Description string            `json:"description,omitempty"`
+	Desc        string            `json:"desc,omitempty"` // 兼容旧字段
+	ActiveForm  string            `json:"active_form,omitempty"`
+	Status      TaskStatus        `json:"status"`
+	BlockedBy   []string          `json:"blocked_by,omitempty"`
+	Blocks      []string          `json:"blocks,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 // IssueNum 从 metadata 获取 issue 编号


### PR DESCRIPTION
## Summary
- 将 `TaskCtlClient` 从旧调用 `taskctl task ...` 迁移到当前扁平 CLI（`taskctl create/list/update/...`）
- 对 status 做兼容映射（支持历史 `in_progress`，统一映射为 `in-progress`）
- 对 metadata 参数改为 JSON 传递（兼容当前 taskctl）
- 补充 taskctl 兼容单测（命令参数映射、状态归一化）
- 修正 `FormatStatus` 测试中 `in_progress` 断言

## Test Plan
- `cd automation/niuma && go test ./...`
- 真实冒烟：`cd automation/niuma && go run ./cmd/niuma control run --repo biantaishabi2/Cli --repo-dir /tmp/niuma-e2e-mode1`
- 真实冒烟：`cd automation/niuma && go run ./cmd/niuma control run --repo biantaishabi2/Cli --repo-dir /tmp/niuma-e2e-mode2`

Closes #168
