### PR TITLE
fix: 避免 discuss 自触发取消并增加超时 (#239)

### DIFF
--- a/.github/workflows/niuma-discuss.yml
+++ b/.github/workflows/niuma-discuss.yml
@@ -6,13 +6,13 @@ on:
   issue_comment:
     types: [created]
 
-concurrency:
-  group: niuma-discuss-${{ github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   discussion-check:
     runs-on: self-hosted
+    timeout-minutes: 30
+    concurrency:
+      group: niuma-discuss-${{ github.event.issue.number }}
+      cancel-in-progress: true
     if: >
       github.event.issue.pull_request == null &&
       (
@@ -47,5 +47,5 @@ jobs:
           if echo "$LABELS" | grep -q "bot:needs-discussion"; then
             "$NIUMA_BIN" discuss \
               --repo "$REPO" \
-              --issue "$ISSUE_NUMBER" || true
+              --issue "$ISSUE_NUMBER"
           fi

--- a/.niuma.yml
+++ b/.niuma.yml
@@ -29,6 +29,7 @@ ai:
 
 workflow:
   max_discussion_rounds: 5
+  discuss_timeout_minutes: 20
   max_iterate_rounds: 10
   allowed_prefixes:
     - "automation/"

--- a/.niuma.yml.example
+++ b/.niuma.yml.example
@@ -55,5 +55,7 @@ ai:
 workflow:
   # discuss 单次 run 内最大轮次（1-20，默认 5）
   max_discussion_rounds: 5
+  # discuss 命令超时（分钟，1-120，默认 20）
+  discuss_timeout_minutes: 20
   allowed_prefixes:
     - "automation/"

--- a/automation/niuma/cmd/niuma/main.go
+++ b/automation/niuma/cmd/niuma/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/biantaishabi2/Cli/automation/niuma/pkg/agent"
 	"github.com/biantaishabi2/Cli/automation/niuma/pkg/ai"
@@ -179,7 +180,16 @@ func runDiscuss(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("必须指定 --repo 和 --issue")
 	}
 
-	ctx := context.Background()
+	configDir := "."
+	if flagRepoDir != "" {
+		configDir = flagRepoDir
+	}
+	cfg := config.LoadWithDefaults(configDir)
+
+	discussTimeout := time.Duration(cfg.Workflow.GetDiscussTimeoutMinutes()) * time.Minute
+	ctx, cancel := context.WithTimeout(context.Background(), discussTimeout)
+	defer cancel()
+
 	client, err := gh.NewClientFromEnv(flagRepo)
 	if err != nil {
 		return err
@@ -194,14 +204,9 @@ func runDiscuss(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	configDir := "."
-	if flagRepoDir != "" {
-		configDir = flagRepoDir
-	}
-	cfg := config.LoadWithDefaults(configDir)
 	maxRounds := resolveDiscussMaxRounds(flagMaxDiscussionRounds, cfg.Workflow.GetMaxDiscussionRounds())
 
-	fmt.Printf("正在为 issue #%d 进行讨论检查（max_rounds=%d）...\n", flagIssue, maxRounds)
+	fmt.Printf("正在为 issue #%d 进行讨论检查（max_rounds=%d timeout=%s）...\n", flagIssue, maxRounds, discussTimeout)
 
 	if err := orch.DoDiscuss(ctx, maxRounds); err != nil {
 		return fmt.Errorf("讨论检查失败: %w", err)

--- a/automation/niuma/pkg/config/config.go
+++ b/automation/niuma/pkg/config/config.go
@@ -29,10 +29,11 @@ type ControlConfig struct {
 
 // WorkflowConfig 工作流配置
 type WorkflowConfig struct {
-	RequirePlanApproval bool     `yaml:"require_plan_approval"` // 方案定稿后是否需要人工审批
-	MaxIterateRounds    int      `yaml:"max_iterate_rounds"`    // 最大自动迭代轮数（0=默认3）
-	MaxDiscussionRounds int      `yaml:"max_discussion_rounds"` // discuss 单次 run 的最大讨论轮数（默认 5）
-	AllowedPrefixes     []string `yaml:"allowed_prefixes"`      // 允许修改的路径前缀
+	RequirePlanApproval   bool     `yaml:"require_plan_approval"`   // 方案定稿后是否需要人工审批
+	MaxIterateRounds      int      `yaml:"max_iterate_rounds"`      // 最大自动迭代轮数（0=默认3）
+	MaxDiscussionRounds   int      `yaml:"max_discussion_rounds"`   // discuss 单次 run 的最大讨论轮数（默认 5）
+	DiscussTimeoutMinutes int      `yaml:"discuss_timeout_minutes"` // discuss 命令超时（分钟，默认 20）
+	AllowedPrefixes       []string `yaml:"allowed_prefixes"`        // 允许修改的路径前缀
 }
 
 // GetMaxIterateRounds 获取最大迭代轮数，默认3
@@ -50,6 +51,15 @@ func (w *WorkflowConfig) GetMaxDiscussionRounds() int {
 		return 5
 	}
 	return w.MaxDiscussionRounds
+}
+
+// GetDiscussTimeoutMinutes 获取 discuss 超时分钟数。
+// 合法范围 1-120，越界或未配置都回退默认值 20。
+func (w *WorkflowConfig) GetDiscussTimeoutMinutes() int {
+	if w.DiscussTimeoutMinutes < 1 || w.DiscussTimeoutMinutes > 120 {
+		return 20
+	}
+	return w.DiscussTimeoutMinutes
 }
 
 // AIConfig AI 相关配置
@@ -230,8 +240,9 @@ func defaultConfig() *Config {
 			Templates: map[string]TemplateConfig{},
 		},
 		Workflow: WorkflowConfig{
-			MaxIterateRounds:    3,
-			MaxDiscussionRounds: 5,
+			MaxIterateRounds:      3,
+			MaxDiscussionRounds:   5,
+			DiscussTimeoutMinutes: 20,
 		},
 	}
 }

--- a/automation/niuma/pkg/config/config_test.go
+++ b/automation/niuma/pkg/config/config_test.go
@@ -55,6 +55,7 @@ func TestLoadWithDefaults_FileNotFound(t *testing.T) {
 	assert.Equal(t, "codex", cfg.AI.Default)
 	assert.NotNil(t, cfg.AI.Providers)
 	assert.Equal(t, 5, cfg.Workflow.GetMaxDiscussionRounds())
+	assert.Equal(t, 20, cfg.Workflow.GetDiscussTimeoutMinutes())
 }
 
 func TestLoad_WorkflowConfig(t *testing.T) {
@@ -68,6 +69,7 @@ workflow:
   require_plan_approval: true
   max_iterate_rounds: 5
   max_discussion_rounds: 7
+  discuss_timeout_minutes: 25
 `
 	err := os.WriteFile(filepath.Join(dir, ".niuma.yml"), []byte(content), 0644)
 	require.NoError(t, err)
@@ -79,6 +81,7 @@ workflow:
 	assert.Equal(t, 5, cfg.Workflow.GetMaxIterateRounds())
 	assert.Equal(t, 7, cfg.Workflow.MaxDiscussionRounds)
 	assert.Equal(t, 7, cfg.Workflow.GetMaxDiscussionRounds())
+	assert.Equal(t, 25, cfg.Workflow.GetDiscussTimeoutMinutes())
 }
 
 func TestWorkflowConfig_DefaultMaxRounds(t *testing.T) {
@@ -94,6 +97,14 @@ func TestWorkflowConfig_DefaultMaxRounds(t *testing.T) {
 
 	w.MaxDiscussionRounds = -1
 	assert.Equal(t, 5, w.GetMaxDiscussionRounds())
+
+	assert.Equal(t, 20, w.GetDiscussTimeoutMinutes())
+	w.DiscussTimeoutMinutes = 121
+	assert.Equal(t, 20, w.GetDiscussTimeoutMinutes())
+	w.DiscussTimeoutMinutes = -1
+	assert.Equal(t, 20, w.GetDiscussTimeoutMinutes())
+	w.DiscussTimeoutMinutes = 30
+	assert.Equal(t, 30, w.GetDiscussTimeoutMinutes())
 }
 
 func TestLoad_EnvOverride(t *testing.T) {


### PR DESCRIPTION
## Summary

- 将 `niuma-discuss` 的并发控制从 workflow 顶层下沉到 `discussion-check` job，避免 BOT 触发的 skipped run 取消正在执行的有效 run
- 给 `discussion-check` job 增加 `timeout-minutes: 30`
- 去掉 `niuma discuss` 执行后的 `|| true`，保留失败信号，便于观察和重试
- `runDiscuss` 改为带超时的 context 执行，超时来源于配置项 `workflow.discuss_timeout_minutes`（默认 20，范围 1-120）
- 更新 `.niuma.yml` / `.niuma.yml.example` 和配置测试

## Test plan

- `cd automation/niuma && go test ./cmd/niuma ./pkg/config`
- `cd automation/niuma && go test ./pkg/agent ./pkg/state ./tests/integration -run 'Discuss|Convergence'`

Closes #239
