### PR TITLE
fix: sub(#210): integration merged 事件驱动 issue 收口 (#214)

### DIFF
--- a/.github/workflows/niuma-iterate.yml
+++ b/.github/workflows/niuma-iterate.yml
@@ -5,6 +5,8 @@ on:
     types: [labeled]
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [closed]
 
 concurrency:
   group: niuma-iterate-${{ github.event.issue.number || github.event.pull_request.number }}
@@ -157,3 +159,41 @@ jobs:
             gh issue edit "$ISSUE_NUMBER" --add-label bot:pr-needs-fix
           gh issue comment "$ISSUE_NUMBER" --body "## ❌ Gate 未通过\n\n根据人工 review 迭代后门禁失败，状态保持为 \`bot:pr-needs-fix\`，请继续修复。"
           exit 1
+
+  close-after-integration-merge:
+    runs-on: self-hosted
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'integration/') &&
+      github.event.pull_request.base.ref == 'master'
+    permissions:
+      issues: write
+      pull-requests: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.NIUMA_PAT }}
+
+      - name: Build niuma from current commit
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/.tmp"
+          (
+            cd automation/niuma
+            go build -o "$GITHUB_WORKSPACE/.tmp/niuma" ./cmd/niuma
+          )
+          echo "NIUMA_BIN=$GITHUB_WORKSPACE/.tmp/niuma" >> "$GITHUB_ENV"
+
+      - name: Close Merged Integration Issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          REPO: ${{ github.repository }}
+          WORKSPACE: ${{ github.workspace }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          "$NIUMA_BIN" control close-merged \
+            --repo "$REPO" \
+            --repo-dir "$WORKSPACE" \
+            --pr "$PR_NUMBER"

--- a/.github/workflows/niuma-review.yml
+++ b/.github/workflows/niuma-review.yml
@@ -3,15 +3,19 @@ name: niuma - Review
 on:
   issues:
     types: [labeled]
+  pull_request:
+    types: [closed]
 
 concurrency:
-  group: niuma-review-${{ github.event.issue.number }}
+  group: niuma-review-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
   review:
     runs-on: self-hosted
-    if: github.event.label.name == 'bot:pr-created'
+    if: >
+      github.event_name == 'issues' &&
+      github.event.label.name == 'bot:pr-created'
     permissions:
       issues: write
       pull-requests: write
@@ -63,4 +67,42 @@ jobs:
           "$NIUMA_BIN" review \
             --repo "$REPO" \
             --issue "$ISSUE_NUMBER" \
+            --pr "$PR_NUMBER"
+
+  close-after-integration-merge:
+    runs-on: self-hosted
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'integration/') &&
+      github.event.pull_request.base.ref == 'master'
+    permissions:
+      issues: write
+      pull-requests: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.NIUMA_PAT }}
+
+      - name: Build niuma from current commit
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/.tmp"
+          (
+            cd automation/niuma
+            go build -o "$GITHUB_WORKSPACE/.tmp/niuma" ./cmd/niuma
+          )
+          echo "NIUMA_BIN=$GITHUB_WORKSPACE/.tmp/niuma" >> "$GITHUB_ENV"
+
+      - name: Close Merged Integration Issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          REPO: ${{ github.repository }}
+          WORKSPACE: ${{ github.workspace }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          "$NIUMA_BIN" control close-merged \
+            --repo "$REPO" \
+            --repo-dir "$WORKSPACE" \
             --pr "$PR_NUMBER"

--- a/automation/niuma/pkg/control/controller.go
+++ b/automation/niuma/pkg/control/controller.go
@@ -472,6 +472,27 @@ func (c *Controller) FinalizeIntegratedIssues(ctx context.Context, issueNums []i
 		return nil
 	}
 
+	if c.taskctl != nil {
+		tasks, err := c.taskctl.List("")
+		if err != nil {
+			return fmt.Errorf("读取 task 集合失败: %w", err)
+		}
+		filtered, branchBuckets, skipped := c.selectClosableIssueNums(tasks, targets)
+		for _, branch := range sortedBranchNames(branchBuckets) {
+			fmt.Printf("[control] integration 分支 %s 收口候选: %v\n", branch, branchBuckets[branch])
+		}
+		for _, issueNum := range targets {
+			if reason, ok := skipped[issueNum]; ok {
+				fmt.Printf("[control] issue #%d 跳过收口：%s\n", issueNum, reason)
+			}
+		}
+		targets = filtered
+		if len(targets) == 0 {
+			fmt.Println("[control] 未发现满足 completed+integrated 条件的 sub issue，跳过")
+			return nil
+		}
+	}
+
 	parentNums := make(map[int]struct{})
 	var firstErr error
 
@@ -494,10 +515,14 @@ func (c *Controller) FinalizeIntegratedIssues(ctx context.Context, issueNums []i
 			continue
 		}
 
-		if err := c.syncIssueStateLabel(ctx, issueNum, botDoneLabel); err != nil {
-			fmt.Printf("[control] issue #%d 打标 %s 失败: %v\n", issueNum, botDoneLabel, err)
-			if firstErr == nil {
-				firstErr = err
+		if hasLabel(issue.Labels, botDoneLabel) {
+			fmt.Printf("[control] issue #%d 已存在 %s 标签，跳过重复打标\n", issueNum, botDoneLabel)
+		} else {
+			if err := c.syncIssueStateLabel(ctx, issueNum, botDoneLabel); err != nil {
+				fmt.Printf("[control] issue #%d 打标 %s 失败: %v\n", issueNum, botDoneLabel, err)
+				if firstErr == nil {
+					firstErr = err
+				}
 			}
 		}
 		if err := c.github.CloseIssue(ctx, issueNum); err != nil {
@@ -567,10 +592,14 @@ func (c *Controller) closeParentIssuesIfReady(ctx context.Context, parentNums ma
 			continue
 		}
 
-		if err := c.syncIssueStateLabel(ctx, parentNum, botDoneLabel); err != nil {
-			fmt.Printf("[control] parent issue #%d 打标 %s 失败: %v\n", parentNum, botDoneLabel, err)
-			if firstErr == nil {
-				firstErr = err
+		if hasLabel(parentIssue.Labels, botDoneLabel) {
+			fmt.Printf("[control] parent issue #%d 已存在 %s 标签，跳过重复打标\n", parentNum, botDoneLabel)
+		} else {
+			if err := c.syncIssueStateLabel(ctx, parentNum, botDoneLabel); err != nil {
+				fmt.Printf("[control] parent issue #%d 打标 %s 失败: %v\n", parentNum, botDoneLabel, err)
+				if firstErr == nil {
+					firstErr = err
+				}
 			}
 		}
 		if err := c.github.CloseIssue(ctx, parentNum); err != nil {
@@ -1182,4 +1211,94 @@ func uniquePositiveIssueNumbers(nums []int) []int {
 	}
 	sort.Ints(result)
 	return result
+}
+
+func sortedBranchNames(branchBuckets map[string][]int) []string {
+	names := make([]string, 0, len(branchBuckets))
+	for branch := range branchBuckets {
+		names = append(names, branch)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// selectClosableIssueNums 从 task 集合中筛选可收口 issue。
+// 条件：task status=completed 且 metadata.integrated=true。
+func (c *Controller) selectClosableIssueNums(tasks []Task, issueNums []int) ([]int, map[string][]int, map[int]string) {
+	targets := uniquePositiveIssueNumbers(issueNums)
+	targetSet := make(map[int]struct{}, len(targets))
+	for _, issueNum := range targets {
+		targetSet[issueNum] = struct{}{}
+	}
+
+	type taskEval struct {
+		task       Task
+		hasTask    bool
+		status     TaskStatus
+		integrated bool
+	}
+	evals := make(map[int]taskEval, len(targets))
+	for _, task := range tasks {
+		issueNum := task.IssueNum()
+		if issueNum <= 0 {
+			continue
+		}
+		if _, ok := targetSet[issueNum]; !ok {
+			continue
+		}
+
+		status := normalizeTaskStatus(task.Status)
+		integrated := valueOrEmpty(task.Metadata, metaKeyIntegrated) == "true"
+		cur, exists := evals[issueNum]
+		if !exists {
+			evals[issueNum] = taskEval{
+				task:       task,
+				hasTask:    true,
+				status:     status,
+				integrated: integrated,
+			}
+			continue
+		}
+
+		// 多 task 关联同一 issue 时，优先选择满足 completed+integrated 的记录。
+		if status == TaskStatusCompleted && integrated &&
+			!(cur.status == TaskStatusCompleted && cur.integrated) {
+			evals[issueNum] = taskEval{
+				task:       task,
+				hasTask:    true,
+				status:     status,
+				integrated: integrated,
+			}
+		}
+	}
+
+	filtered := make([]int, 0, len(targets))
+	branchBuckets := make(map[string][]int)
+	skipped := make(map[int]string)
+	for _, issueNum := range targets {
+		eval, ok := evals[issueNum]
+		if !ok || !eval.hasTask {
+			skipped[issueNum] = "未找到关联 task"
+			continue
+		}
+
+		if eval.status != TaskStatusCompleted {
+			skipped[issueNum] = fmt.Sprintf("task 状态为 %s", eval.status)
+			continue
+		}
+		if !eval.integrated {
+			skipped[issueNum] = "task 尚未 integrated=true"
+			continue
+		}
+
+		filtered = append(filtered, issueNum)
+		branchName := c.getIntegrationBranchName(&eval.task)
+		branchBuckets[branchName] = append(branchBuckets[branchName], issueNum)
+	}
+
+	for branch, nums := range branchBuckets {
+		sort.Ints(nums)
+		branchBuckets[branch] = nums
+	}
+	return filtered, branchBuckets, skipped
 }

--- a/automation/niuma/pkg/control/controller_test.go
+++ b/automation/niuma/pkg/control/controller_test.go
@@ -855,6 +855,64 @@ func TestFinalizeIntegratedIssues_ClosedIssueIsIdempotent(t *testing.T) {
 	assert.NotContains(t, mockGH.closeIssueCalls, 210)
 }
 
+func TestFinalizeIntegratedIssues_SkipDoneLabelWhenAlreadyPresent(t *testing.T) {
+	mockGH := newMockGitHubOps(
+		IssueInfo{Number: 214, Title: "sub-214", State: "open", Labels: []string{botDoneLabel}},
+	)
+
+	ctrl := &Controller{github: mockGH}
+	err := ctrl.FinalizeIntegratedIssues(context.Background(), []int{214})
+	require.NoError(t, err)
+
+	assert.Contains(t, mockGH.closeIssueCalls, 214)
+	assert.Equal(t, 0, countReplaceLabelByIssueAndTarget(mockGH.replaceLabelCalls, 214, botDoneLabel))
+}
+
+func TestSelectClosableIssueNums_FiltersCompletedAndIntegrated(t *testing.T) {
+	ctrl := &Controller{}
+	tasks := []Task{
+		{
+			Status: TaskStatusCompleted,
+			Metadata: map[string]string{
+				"issue_num":       "214",
+				"meta_issue_slug": "214",
+				metaKeyIntegrated: "true",
+			},
+		},
+		{
+			Status: TaskStatusCompleted,
+			Metadata: map[string]string{
+				"issue_num":       "215",
+				"meta_issue_slug": "214",
+				metaKeyIntegrated: "false",
+			},
+		},
+		{
+			Status: TaskStatusInProgress,
+			Metadata: map[string]string{
+				"issue_num":       "216",
+				"meta_issue_slug": "214",
+				metaKeyIntegrated: "true",
+			},
+		},
+		{
+			Status: TaskStatusCompleted,
+			Metadata: map[string]string{
+				"issue_num":       "217",
+				metaKeyIntegrated: "true",
+			},
+		},
+	}
+
+	filtered, branchBuckets, skipped := ctrl.selectClosableIssueNums(tasks, []int{214, 215, 216, 217, 218})
+	assert.Equal(t, []int{214, 217}, filtered)
+	assert.Equal(t, []int{214}, branchBuckets["integration/214"])
+	assert.Equal(t, []int{217}, branchBuckets["integration/main"])
+	assert.Equal(t, "task 尚未 integrated=true", skipped[215])
+	assert.Equal(t, "task 状态为 in-progress", skipped[216])
+	assert.Equal(t, "未找到关联 task", skipped[218])
+}
+
 func countReplaceLabelByTarget(calls []replaceLabelCall, label string) int {
 	count := 0
 	for _, call := range calls {

--- a/automation/niuma/pkg/github/issues.go
+++ b/automation/niuma/pkg/github/issues.go
@@ -5,6 +5,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/go-github/v68/github"
 )
@@ -98,9 +99,17 @@ func (c *Client) ListIssuesByState(ctx context.Context, state string) ([]*github
 
 // CloseIssue 关闭指定 issue
 func (c *Client) CloseIssue(ctx context.Context, number int) error {
+	issue, _, err := c.gh.Issues.Get(ctx, c.owner, c.repo, number)
+	if err != nil {
+		return fmt.Errorf("获取 issue #%d 失败: %w", number, err)
+	}
+	if strings.EqualFold(issue.GetState(), "closed") {
+		return nil
+	}
+
 	state := "closed"
 	req := &github.IssueRequest{State: &state}
-	_, _, err := c.gh.Issues.Edit(ctx, c.owner, c.repo, number, req)
+	_, _, err = c.gh.Issues.Edit(ctx, c.owner, c.repo, number, req)
 	if err != nil {
 		return fmt.Errorf("关闭 issue #%d 失败: %w", number, err)
 	}


### PR DESCRIPTION
Closes #214

## Summary

## ✅ 最终方案：sub(#210) integration merged 事件驱动 sub issue 自动收口最终方案

### 实现方案

以已合入 master 的 commit f74f4c2 为实现基线，构建“事件触发 -> 任务定位 -> 条件收口 -> 幂等退出”的闭环。具体为：1) 在 niuma 相关 workflow 中监听 pull_request.closed，并通过 merged=true、head=integration/*、base=master 进行准入过滤；2) 触发后统一调用 `niuma control close-merged --pr <number>` 作为唯一收口入口，避免人工介入；3) controller 层按 integration 任务集合解析并筛选仅 `completed + integrated` 的 sub issues；4) github issues 操作层执行关闭与 `bot:done` 打标时做幂等保护（已关闭/已存在标签直接跳过）；5) 重复触发场景保持无副作用并记录可审计日志。该方案满足“自动收口稳定”和“重复触发幂等”两项验收标准，并保留后续可选优化：双 workflow 同时监听时增加 concurrency group 以减少重复执行日志。

### 文件变更

| 路径 | 操作 | 描述 |
|------|------|------|
| `.github/workflows/niuma-iterate.yml` | modify | 新增 `pull_request.closed` 触发与 merged/integration 分支条件判断，接入 close-merged 收口任务。 |
| `.github/workflows/niuma-review.yml` | modify | 补充 integration PR merge 事件监听与收口步骤，确保 review 侧同样可驱动收口。 |
| `automation/niuma/pkg/control/controller.go` | modify | 实现/强化 `close-merged` 收口编排：定位 integration 任务集合，仅关闭 completed+integrated 子任务，重复触发时幂等跳过。 |
| `automation/niuma/pkg/github/issues.go` | modify | 封装 issue 关闭与 `bot:done` 标签操作的幂等逻辑（已关闭/已打标不报错），统一错误返回与日志。 |

### 测试场景

1. **integration PR 人工 merge 自动收口**: 输入 `pull_request.closed, merged=true, head=integration/214, base=master；关联子任务含 completed+integrated(open)` → 预期 `对应 completed+integrated 子任务自动关闭并打 `bot:done`。`
2. **已关闭 issue 重复触发**: 输入 `同一 merge 事件重复触发，目标子任务已是 closed 且已带 `bot:done`` → 预期 `流程幂等成功，状态不变，无异常。`
3. **混合状态子任务过滤**: 输入 `子任务同时存在 completed+integrated、completed-only、integrated-only、open/closed 混合` → 预期 `仅 completed+integrated 且 open 的子任务被处理，其余全部跳过。`


---
*方案已定稿，即将开始实现。*
<!-- PLAN_FILES:[{"path":".github/workflows/niuma-iterate.yml","action":"modify","description":"新增 `pull_request.closed` 触发与 merged/integration 分支条件判断，接入 close-merged 收口任务。"},{"path":".github/workflows/niuma-review.yml","action":"modify","description":"补充 integration PR merge 事件监听与收口步骤，确保 review 侧同样可驱动收口。"},{"path":"automation/niuma/pkg/control/controller.go","action":"modify","description":"实现/强化 `close-merged` 收口编排：定位 integration 任务集合，仅关闭 completed+integrated 子任务，重复触发时幂等跳过。"},{"path":"automation/niuma/pkg/github/issues.go","action":"modify","description":"封装 issue 关闭与 `bot:done` 标签操作的幂等逻辑（已关闭/已打标不报错），统一错误返回与日志。"}] -->