### PR TITLE
fix: feat(workflow): 冲突修复 Profile 化（通用提示词 + Go/Elixir/Rust 门禁） (#344)

### DIFF
--- a/automation/niuma/README.md
+++ b/automation/niuma/README.md
@@ -170,6 +170,11 @@ control:
 - `--pr-conflict-enable-ai`（默认 `true`）
 - `--pr-conflict-ai-max-attempts`（默认 `2`）
 - `--pr-conflict-smoke-test-cmd`（默认关闭）
+- `--pr-conflict-profile-go-enabled / --pr-conflict-profile-elixir-enabled / --pr-conflict-profile-rust-enabled`（默认均为 `true`）
+- `--pr-conflict-profile-go-gate-cmd`（默认 `go test {pkg}`）
+- `--pr-conflict-profile-elixir-gate-cmd`（默认 `mix test {scope}`）
+- `--pr-conflict-profile-rust-gate-cmd`（默认 `cargo test --manifest-path {path}`）
+- `--pr-conflict-max-hunks / --pr-conflict-max-hunk-lines / --pr-conflict-max-total-lines`（默认 `3 / 15 / 50`）
 
 ## 状态机（Labels）
 
@@ -211,20 +216,30 @@ niuma state-label clear --repo owner/repo --issue 325
 
 - control 循环会持续检查 `bot:pr-reviewable` 对应 PR 的 `mergeable / mergeStateStatus / headSha`
 - 命中冲突条件（`mergeable=CONFLICTING` 或 `mergeStateStatus in {DIRTY,BLOCKED}`）时，进入分层修复：
-  - Rule 层：仅处理 Go `import` 区域冲突（并集/去重/排序）
-  - AI 层：仅在 Rule 失败后触发，默认最多重试 `2` 次（`--pr-conflict-ai-max-attempts`）
-  - Human 层：Rule + AI 失败或达上限后自动升级 `needs-human`
+  - Rule 层：按 profile 插件执行（Go: `import`；Elixir: `alias/import/use`；Rust: `use/mod`）
+  - AI 层：仅在 Rule 失败后触发，Prompt 采用 `Common + Profile` 两段式拼装，默认最多重试 `2` 次（`--pr-conflict-ai-max-attempts`）
+  - Human 层：Rule + AI 失败、profile 禁用、识别失败（`unknown`）或超阈值时自动升级 `needs-human`
+- profile 识别规则：后缀优先（`.go/.ex/.exs/.rs`）→ 目录标记兜底（`go.mod/mix.exs/Cargo.toml`）→ `unknown` 直接升级 human
+- 多文件冲突会按 profile 分组串行处理；任一分组失败触发统一回滚事务
 - 预检查：`git diff --name-only --diff-filter=U` 为空时直接 no-op（不改状态/标签）
-- Rule/AI 共用统一门禁（必须全过）：
+- Rule/AI 共用 Common Gate（必须全过）：
   - 结构门禁：不得残留 `<<<<<<<` / `=======` / `>>>>>>>`
   - 变更范围门禁：`git diff --name-only` 仅允许冲突文件
-  - 质量门禁：冲突文件所在 Go 包 `go test` 必过；可选执行 `--pr-conflict-smoke-test-cmd`
-- 安全边界：AI 仅对白名单冲突类型启用（import、测试辅助代码轻度并合、轻度相邻块冲突）；检测到高风险冲突（核心接口语义变更/迁移脚本/大规模冲突）直接升级 Human
+- Profile Gate（按语言路由）：
+  - Go：默认 `go test {pkg}`
+  - Elixir：默认 `mix test {scope}`
+  - Rust：默认 `cargo test --manifest-path {path}`
+  - 可选执行全局 smoke：`--pr-conflict-smoke-test-cmd`
+- 安全边界：默认阈值 `hunks<=3`、`单 hunk<=15`、`总冲突行<=50`；超过阈值直接升级 Human
 - 可观测 metadata：
   - `conflict_resolution_layer`
   - `conflict_resolution_attempts`
+  - `conflict_resolution_profile`
+  - `conflict_resolution_files`
   - `conflict_resolution_last_error`
   - `conflict_resolution_last_failed_at`
+  - `gate_passed`
+  - `resolution_path`
 - 评论会记录层级切换并带 marker 去重：`rule-fail -> ai-try -> human-escalate`
 - `UNKNOWN` 状态仍按指数退避短重试（默认 `5s,15s,30s`），耗尽后保守 no-op
 

--- a/automation/niuma/cmd/niuma/control.go
+++ b/automation/niuma/cmd/niuma/control.go
@@ -75,6 +75,15 @@ var flagPRConflictUnknownBackoffs string
 var flagPRConflictEnableAI bool
 var flagPRConflictAIMaxAttempts int
 var flagPRConflictSmokeTestCmd string
+var flagPRConflictGoProfileEnabled bool
+var flagPRConflictElixirProfileEnabled bool
+var flagPRConflictRustProfileEnabled bool
+var flagPRConflictGoGateCmd string
+var flagPRConflictElixirGateCmd string
+var flagPRConflictRustGateCmd string
+var flagPRConflictMaxHunks int
+var flagPRConflictMaxHunkLines int
+var flagPRConflictMaxTotalLines int
 
 func init() {
 	controlCmd.AddCommand(controlRunCmd)
@@ -95,6 +104,15 @@ func init() {
 	controlRunCmd.Flags().BoolVar(&flagPRConflictEnableAI, "pr-conflict-enable-ai", true, "是否启用冲突 AI 修复层（Rule 失败后触发）")
 	controlRunCmd.Flags().IntVar(&flagPRConflictAIMaxAttempts, "pr-conflict-ai-max-attempts", 2, "冲突 AI 修复最大尝试次数（默认 2）")
 	controlRunCmd.Flags().StringVar(&flagPRConflictSmokeTestCmd, "pr-conflict-smoke-test-cmd", "", "冲突修复门禁可选 smoke test 命令（默认关闭）")
+	controlRunCmd.Flags().BoolVar(&flagPRConflictGoProfileEnabled, "pr-conflict-profile-go-enabled", true, "是否启用 Go 冲突 profile")
+	controlRunCmd.Flags().BoolVar(&flagPRConflictElixirProfileEnabled, "pr-conflict-profile-elixir-enabled", true, "是否启用 Elixir 冲突 profile")
+	controlRunCmd.Flags().BoolVar(&flagPRConflictRustProfileEnabled, "pr-conflict-profile-rust-enabled", true, "是否启用 Rust 冲突 profile")
+	controlRunCmd.Flags().StringVar(&flagPRConflictGoGateCmd, "pr-conflict-profile-go-gate-cmd", "go test {pkg}", "Go profile 门禁命令模板")
+	controlRunCmd.Flags().StringVar(&flagPRConflictElixirGateCmd, "pr-conflict-profile-elixir-gate-cmd", "mix test {scope}", "Elixir profile 门禁命令模板")
+	controlRunCmd.Flags().StringVar(&flagPRConflictRustGateCmd, "pr-conflict-profile-rust-gate-cmd", "cargo test --manifest-path {path}", "Rust profile 门禁命令模板")
+	controlRunCmd.Flags().IntVar(&flagPRConflictMaxHunks, "pr-conflict-max-hunks", 3, "冲突自动修复阈值：单文件 hunk 数上限")
+	controlRunCmd.Flags().IntVar(&flagPRConflictMaxHunkLines, "pr-conflict-max-hunk-lines", 15, "冲突自动修复阈值：单 hunk 行数上限")
+	controlRunCmd.Flags().IntVar(&flagPRConflictMaxTotalLines, "pr-conflict-max-total-lines", 50, "冲突自动修复阈值：总冲突行数上限")
 	controlCloseMergedCmd.MarkFlagRequired("pr")
 }
 
@@ -174,7 +192,38 @@ func buildController() (*control.Controller, error) {
 		PRConflictEnableAI:        flagPRConflictEnableAI,
 		PRConflictAIMaxAttempts:   flagPRConflictAIMaxAttempts,
 		PRConflictSmokeTestCmd:    flagPRConflictSmokeTestCmd,
-		RepoDir:                   repoDir,
+		ConflictResolution: control.PRConflictResolutionConfig{
+			Profiles: map[string]control.PRConflictProfileConfig{
+				"go": {
+					Enabled:     flagPRConflictGoProfileEnabled,
+					GateCommand: flagPRConflictGoGateCmd,
+					Threshold: control.PRConflictThresholdConfig{
+						MaxHunks:      flagPRConflictMaxHunks,
+						MaxHunkLines:  flagPRConflictMaxHunkLines,
+						MaxTotalLines: flagPRConflictMaxTotalLines,
+					},
+				},
+				"elixir": {
+					Enabled:     flagPRConflictElixirProfileEnabled,
+					GateCommand: flagPRConflictElixirGateCmd,
+					Threshold: control.PRConflictThresholdConfig{
+						MaxHunks:      flagPRConflictMaxHunks,
+						MaxHunkLines:  flagPRConflictMaxHunkLines,
+						MaxTotalLines: flagPRConflictMaxTotalLines,
+					},
+				},
+				"rust": {
+					Enabled:     flagPRConflictRustProfileEnabled,
+					GateCommand: flagPRConflictRustGateCmd,
+					Threshold: control.PRConflictThresholdConfig{
+						MaxHunks:      flagPRConflictMaxHunks,
+						MaxHunkLines:  flagPRConflictMaxHunkLines,
+						MaxTotalLines: flagPRConflictMaxTotalLines,
+					},
+				},
+			},
+		},
+		RepoDir: repoDir,
 	}
 
 	builder := control.NewIntegrationBuilder(

--- a/automation/niuma/cmd/niuma/control_test.go
+++ b/automation/niuma/cmd/niuma/control_test.go
@@ -277,6 +277,18 @@ func TestControlRunFlags_PRConflictLayeredOptionsExist(t *testing.T) {
 	smoke := controlRunCmd.Flags().Lookup("pr-conflict-smoke-test-cmd")
 	require.NotNil(t, smoke)
 	assert.Equal(t, "", smoke.DefValue)
+
+	goProfile := controlRunCmd.Flags().Lookup("pr-conflict-profile-go-enabled")
+	require.NotNil(t, goProfile)
+	assert.Equal(t, "true", goProfile.DefValue)
+
+	elixirProfile := controlRunCmd.Flags().Lookup("pr-conflict-profile-elixir-enabled")
+	require.NotNil(t, elixirProfile)
+	assert.Equal(t, "true", elixirProfile.DefValue)
+
+	rustProfile := controlRunCmd.Flags().Lookup("pr-conflict-profile-rust-enabled")
+	require.NotNil(t, rustProfile)
+	assert.Equal(t, "true", rustProfile.DefValue)
 }
 
 func TestWorkflowGateStatusJQ_ObjectTasksPending(t *testing.T) {

--- a/automation/niuma/pkg/control/conflict_profile.go
+++ b/automation/niuma/pkg/control/conflict_profile.go
@@ -1,0 +1,876 @@
+package control
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	conflictProfileUnknown = "unknown"
+	conflictProfileGo      = "go"
+	conflictProfileElixir  = "elixir"
+	conflictProfileRust    = "rust"
+
+	defaultPRConflictMaxHunks      = 3
+	defaultPRConflictMaxHunkLines  = 15
+	defaultPRConflictMaxTotalLines = 50
+
+	defaultGoProfileGateCommand     = "go test {pkg}"
+	defaultElixirProfileGateCommand = "mix test {scope}"
+	defaultRustProfileGateCommand   = "cargo test --manifest-path {path}"
+)
+
+// ConflictProfile 定义语言 profile 的最小契约。
+type ConflictProfile interface {
+	Name() string
+	Detect(repoDir, relPath string) bool
+	Allow(relPath string, summary conflictFileSummary, threshold PRConflictThresholdConfig) (bool, string)
+	ApplyRuleFix(repoDir, relPath string) (bool, error)
+	PromptAddon() string
+	GateCommands(repoDir string, files []string, cfg PRConflictProfileConfig) ([]profileGateCommand, error)
+}
+
+type profileGateCommand struct {
+	Dir     string
+	Command string
+}
+
+type conflictProfileGroup struct {
+	Name    string
+	Profile ConflictProfile
+	Files   []string
+}
+
+// ProfileRegistry 用于管理 profile 注册与识别。
+type ProfileRegistry struct {
+	profiles map[string]ConflictProfile
+}
+
+// NewProfileRegistry 创建空 profile 注册表。
+func NewProfileRegistry() *ProfileRegistry {
+	return &ProfileRegistry{profiles: make(map[string]ConflictProfile)}
+}
+
+func defaultConflictProfileRegistry() *ProfileRegistry {
+	registry := NewProfileRegistry()
+	registry.Register(goConflictProfile{})
+	registry.Register(elixirConflictProfile{})
+	registry.Register(rustConflictProfile{})
+	return registry
+}
+
+// Register 注册 profile。
+func (r *ProfileRegistry) Register(profile ConflictProfile) {
+	if r == nil || profile == nil {
+		return
+	}
+	r.profiles[profile.Name()] = profile
+}
+
+func (r *ProfileRegistry) Profile(name string) (ConflictProfile, bool) {
+	if r == nil {
+		return nil, false
+	}
+	profile, ok := r.profiles[strings.TrimSpace(name)]
+	return profile, ok
+}
+
+// DetectByFile 按“后缀优先、目录标记兜底”识别 profile。
+func (r *ProfileRegistry) DetectByFile(repoDir, relPath string) string {
+	ext := strings.ToLower(filepath.Ext(relPath))
+	switch ext {
+	case ".go":
+		return conflictProfileGo
+	case ".ex", ".exs":
+		return conflictProfileElixir
+	case ".rs":
+		return conflictProfileRust
+	}
+	return detectProfileByProjectMarker(repoDir, relPath)
+}
+
+func detectProfileByProjectMarker(repoDir, relPath string) string {
+	start := filepath.Join(repoDir, filepath.Dir(relPath))
+	if strings.TrimSpace(start) == "" {
+		start = repoDir
+	}
+
+	for dir := start; dir != ""; dir = filepath.Dir(dir) {
+		for _, marker := range []struct {
+			filename string
+			profile  string
+		}{
+			{filename: "go.mod", profile: conflictProfileGo},
+			{filename: "mix.exs", profile: conflictProfileElixir},
+			{filename: "Cargo.toml", profile: conflictProfileRust},
+		} {
+			if _, err := os.Stat(filepath.Join(dir, marker.filename)); err == nil {
+				return marker.profile
+			}
+		}
+		if samePath(dir, repoDir) {
+			break
+		}
+		next := filepath.Dir(dir)
+		if next == dir {
+			break
+		}
+	}
+	return conflictProfileUnknown
+}
+
+func groupConflictFilesByProfile(repoDir string, files []string, registry *ProfileRegistry) ([]conflictProfileGroup, []string) {
+	if registry == nil {
+		registry = defaultConflictProfileRegistry()
+	}
+
+	groupIndex := make(map[string]int)
+	groups := make([]conflictProfileGroup, 0)
+	unknown := make([]string, 0)
+
+	for _, file := range files {
+		profileName := registry.DetectByFile(repoDir, file)
+		if profileName == conflictProfileUnknown {
+			unknown = append(unknown, file)
+			continue
+		}
+
+		profile, ok := registry.Profile(profileName)
+		if !ok || !profile.Detect(repoDir, file) {
+			unknown = append(unknown, file)
+			continue
+		}
+
+		idx, exists := groupIndex[profileName]
+		if !exists {
+			idx = len(groups)
+			groupIndex[profileName] = idx
+			groups = append(groups, conflictProfileGroup{
+				Name:    profileName,
+				Profile: profile,
+				Files:   make([]string, 0),
+			})
+		}
+		groups[idx].Files = append(groups[idx].Files, file)
+	}
+
+	for i := range groups {
+		sort.Strings(groups[i].Files)
+	}
+	sort.Strings(unknown)
+	return groups, unknown
+}
+
+func summarizeConflictProfileGroups(groups []conflictProfileGroup) string {
+	if len(groups) == 0 {
+		return ""
+	}
+	if len(groups) == 1 {
+		return groups[0].Name
+	}
+	parts := make([]string, 0, len(groups))
+	for _, group := range groups {
+		parts = append(parts, fmt.Sprintf("%s:%d", group.Name, len(group.Files)))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+func formatConflictFileList(files []string) string {
+	items := append([]string(nil), files...)
+	sort.Strings(items)
+	return strings.Join(items, ",")
+}
+
+func defaultPRConflictResolutionConfig() PRConflictResolutionConfig {
+	threshold := PRConflictThresholdConfig{
+		MaxHunks:      defaultPRConflictMaxHunks,
+		MaxHunkLines:  defaultPRConflictMaxHunkLines,
+		MaxTotalLines: defaultPRConflictMaxTotalLines,
+	}
+	return PRConflictResolutionConfig{
+		Profiles: map[string]PRConflictProfileConfig{
+			conflictProfileGo: {
+				Enabled:     true,
+				GateCommand: defaultGoProfileGateCommand,
+				Threshold:   threshold,
+			},
+			conflictProfileElixir: {
+				Enabled:     true,
+				GateCommand: defaultElixirProfileGateCommand,
+				Threshold:   threshold,
+			},
+			conflictProfileRust: {
+				Enabled:     true,
+				GateCommand: defaultRustProfileGateCommand,
+				Threshold:   threshold,
+			},
+		},
+	}
+}
+
+func normalizePRConflictResolutionConfig(cfg PRConflictResolutionConfig) PRConflictResolutionConfig {
+	defaults := defaultPRConflictResolutionConfig()
+	if len(cfg.Profiles) == 0 {
+		return defaults
+	}
+
+	normalized := PRConflictResolutionConfig{Profiles: make(map[string]PRConflictProfileConfig, len(defaults.Profiles))}
+	for profileName, defaultCfg := range defaults.Profiles {
+		candidate := defaultCfg
+		if userCfg, ok := cfg.Profiles[profileName]; ok {
+			candidate.Enabled = userCfg.Enabled
+			if strings.TrimSpace(userCfg.GateCommand) != "" {
+				candidate.GateCommand = strings.TrimSpace(userCfg.GateCommand)
+			}
+			if userCfg.Threshold.MaxHunks > 0 {
+				candidate.Threshold.MaxHunks = userCfg.Threshold.MaxHunks
+			}
+			if userCfg.Threshold.MaxHunkLines > 0 {
+				candidate.Threshold.MaxHunkLines = userCfg.Threshold.MaxHunkLines
+			}
+			if userCfg.Threshold.MaxTotalLines > 0 {
+				candidate.Threshold.MaxTotalLines = userCfg.Threshold.MaxTotalLines
+			}
+		}
+		candidate.Threshold = normalizePRConflictThresholdConfig(candidate.Threshold)
+		normalized.Profiles[profileName] = candidate
+	}
+	return normalized
+}
+
+func normalizePRConflictThresholdConfig(cfg PRConflictThresholdConfig) PRConflictThresholdConfig {
+	if cfg.MaxHunks <= 0 {
+		cfg.MaxHunks = defaultPRConflictMaxHunks
+	}
+	if cfg.MaxHunkLines <= 0 {
+		cfg.MaxHunkLines = defaultPRConflictMaxHunkLines
+	}
+	if cfg.MaxTotalLines <= 0 {
+		cfg.MaxTotalLines = defaultPRConflictMaxTotalLines
+	}
+	return cfg
+}
+
+func lookupPRConflictProfileConfig(cfg PRConflictResolutionConfig, profileName string) PRConflictProfileConfig {
+	normalized := normalizePRConflictResolutionConfig(cfg)
+	if profileCfg, ok := normalized.Profiles[profileName]; ok {
+		return profileCfg
+	}
+	threshold := PRConflictThresholdConfig{
+		MaxHunks:      defaultPRConflictMaxHunks,
+		MaxHunkLines:  defaultPRConflictMaxHunkLines,
+		MaxTotalLines: defaultPRConflictMaxTotalLines,
+	}
+	return PRConflictProfileConfig{Enabled: false, Threshold: threshold}
+}
+
+func conflictMetadataFromGroups(groups []conflictProfileGroup, files []string) ConflictResolutionMeta {
+	return ConflictResolutionMeta{
+		Profile:    summarizeConflictProfileGroups(groups),
+		Files:      append([]string(nil), files...),
+		GatePassed: false,
+	}
+}
+
+func allowConflictByThreshold(summary conflictFileSummary, threshold PRConflictThresholdConfig) (bool, string) {
+	if summary.hunks == 0 || len(summary.blocks) == 0 {
+		return false, "未识别到可处理的文本冲突块"
+	}
+	if summary.hunks > threshold.MaxHunks {
+		return false, fmt.Sprintf("冲突块过多: %d", summary.hunks)
+	}
+
+	totalLines := 0
+	for _, block := range summary.blocks {
+		ours := countConflictSideLines(block.ours)
+		theirs := countConflictSideLines(block.theirs)
+		if ours > threshold.MaxHunkLines || theirs > threshold.MaxHunkLines {
+			return false, fmt.Sprintf("单块冲突行数过多: ours=%d theirs=%d", ours, theirs)
+		}
+		totalLines += ours + theirs
+	}
+	if totalLines > threshold.MaxTotalLines {
+		return false, fmt.Sprintf("冲突行数过多: %d", totalLines)
+	}
+	return true, ""
+}
+
+func hasProfileHighRiskSignal(file string, summary conflictFileSummary) (bool, string) {
+	fileLower := strings.ToLower(file)
+	if strings.Contains(fileLower, "migration") || strings.HasSuffix(fileLower, ".sql") {
+		return true, "检测到迁移脚本冲突"
+	}
+	for _, block := range summary.blocks {
+		if containsCoreInterfaceSignal(block.ours + "\n" + block.theirs) {
+			return true, "检测到核心接口语义变更信号"
+		}
+	}
+	return false, ""
+}
+
+func isAdjacentMildConflictWithLimit(fileSummary conflictFileSummary, maxLines int) bool {
+	if fileSummary.hunks > 2 {
+		return false
+	}
+	for _, block := range fileSummary.blocks {
+		if countConflictSideLines(block.ours) > maxLines {
+			return false
+		}
+		if countConflictSideLines(block.theirs) > maxLines {
+			return false
+		}
+	}
+	return true
+}
+
+func isLightweightGoTestConflictWithLimit(file string, fileSummary conflictFileSummary, maxLines int) bool {
+	if !strings.HasSuffix(strings.ToLower(file), "_test.go") {
+		return false
+	}
+	if fileSummary.hunks > 2 {
+		return false
+	}
+	for _, block := range fileSummary.blocks {
+		if countConflictSideLines(block.ours) > maxLines {
+			return false
+		}
+		if countConflictSideLines(block.theirs) > maxLines {
+			return false
+		}
+	}
+	return true
+}
+
+type goConflictProfile struct{}
+
+func (goConflictProfile) Name() string {
+	return conflictProfileGo
+}
+
+func (goConflictProfile) Detect(repoDir string, relPath string) bool {
+	if strings.EqualFold(filepath.Ext(relPath), ".go") {
+		return true
+	}
+	return detectProfileByProjectMarker(repoDir, relPath) == conflictProfileGo
+}
+
+func (goConflictProfile) Allow(relPath string, summary conflictFileSummary, threshold PRConflictThresholdConfig) (bool, string) {
+	if ok, reason := allowConflictByThreshold(summary, threshold); !ok {
+		return false, reason
+	}
+	if risky, reason := hasProfileHighRiskSignal(relPath, summary); risky {
+		return false, reason
+	}
+	if isGoImportConflictOnly(summary) {
+		return true, "go import 冲突"
+	}
+	if isLightweightGoTestConflictWithLimit(relPath, summary, threshold.MaxHunkLines) {
+		return true, "测试辅助代码轻度并合"
+	}
+	if isAdjacentMildConflictWithLimit(summary, threshold.MaxHunkLines) {
+		return true, "轻度相邻块冲突"
+	}
+	return false, "未命中 Go 白名单冲突类型"
+}
+
+func (goConflictProfile) ApplyRuleFix(repoDir, relPath string) (bool, error) {
+	if strings.ToLower(filepath.Ext(relPath)) != ".go" {
+		return false, fmt.Errorf("Rule 层仅支持 Go import 冲突，发现非 Go 文件: %s", relPath)
+	}
+	if err := resolveGoImportConflictFile(repoDir, relPath); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (goConflictProfile) PromptAddon() string {
+	return strings.TrimSpace(`
+[Profile: Go]
+- 优先处理 import 语句冲突，保留并集合并、去重与稳定排序。
+- 保持 gofmt 兼容，不引入无关语义修改。
+- 禁止删除非冲突区域的函数、类型、接口定义。
+`)
+}
+
+func (goConflictProfile) GateCommands(repoDir string, files []string, cfg PRConflictProfileConfig) ([]profileGateCommand, error) {
+	template := strings.TrimSpace(cfg.GateCommand)
+	if template == "" {
+		template = defaultGoProfileGateCommand
+	}
+	targets := collectGoTestTargets(repoDir, files)
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("未找到 Go 测试目标")
+	}
+
+	commands := make([]profileGateCommand, 0, len(targets))
+	for _, target := range targets {
+		command := renderGateCommandTemplate(template, map[string]string{
+			"pkg":      target.pkgPattern,
+			"scope":    target.pkgPattern,
+			"path":     target.pkgPattern,
+			"manifest": filepath.ToSlash(filepath.Join(target.moduleRoot, "go.mod")),
+		})
+		if strings.TrimSpace(command) == "" {
+			continue
+		}
+		commands = append(commands, profileGateCommand{Dir: target.moduleRoot, Command: command})
+	}
+	return commands, nil
+}
+
+type elixirConflictProfile struct{}
+
+func (elixirConflictProfile) Name() string {
+	return conflictProfileElixir
+}
+
+func (elixirConflictProfile) Detect(repoDir, relPath string) bool {
+	ext := strings.ToLower(filepath.Ext(relPath))
+	if ext == ".ex" || ext == ".exs" {
+		return true
+	}
+	return detectProfileByProjectMarker(repoDir, relPath) == conflictProfileElixir
+}
+
+func (elixirConflictProfile) Allow(_ string, summary conflictFileSummary, threshold PRConflictThresholdConfig) (bool, string) {
+	if ok, reason := allowConflictByThreshold(summary, threshold); !ok {
+		return false, reason
+	}
+	if isElixirDirectiveConflictOnly(summary) {
+		return true, "elixir alias/import/use 轻度冲突"
+	}
+	return false, "未命中 Elixir 白名单冲突类型"
+}
+
+func (elixirConflictProfile) ApplyRuleFix(repoDir, relPath string) (bool, error) {
+	if err := resolveElixirDirectiveConflictFile(repoDir, relPath); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (elixirConflictProfile) PromptAddon() string {
+	return strings.TrimSpace(`
+[Profile: Elixir]
+- 仅做 alias/import/use 冲突并合，保持最小改动。
+- 保持模块结构、do/end 配对与缩进风格。
+- 禁止跨文件重构与宏语义重写。
+`)
+}
+
+func (elixirConflictProfile) GateCommands(repoDir string, files []string, cfg PRConflictProfileConfig) ([]profileGateCommand, error) {
+	template := strings.TrimSpace(cfg.GateCommand)
+	if template == "" {
+		template = defaultElixirProfileGateCommand
+	}
+	roots := collectProjectMarkerRoots(repoDir, files, "mix.exs")
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("未找到 Elixir 项目根目录 mix.exs")
+	}
+
+	commands := make([]profileGateCommand, 0, len(roots))
+	for _, root := range roots {
+		scope := deriveElixirGateScope(root, repoDir, files)
+		command := renderGateCommandTemplate(template, map[string]string{
+			"scope": scope,
+			"path":  scope,
+		})
+		if strings.TrimSpace(command) == "" {
+			continue
+		}
+		commands = append(commands, profileGateCommand{Dir: root, Command: command})
+	}
+	return commands, nil
+}
+
+type rustConflictProfile struct{}
+
+func (rustConflictProfile) Name() string {
+	return conflictProfileRust
+}
+
+func (rustConflictProfile) Detect(repoDir, relPath string) bool {
+	if strings.EqualFold(filepath.Ext(relPath), ".rs") {
+		return true
+	}
+	return detectProfileByProjectMarker(repoDir, relPath) == conflictProfileRust
+}
+
+func (rustConflictProfile) Allow(_ string, summary conflictFileSummary, threshold PRConflictThresholdConfig) (bool, string) {
+	if ok, reason := allowConflictByThreshold(summary, threshold); !ok {
+		return false, reason
+	}
+	if isRustDirectiveConflictOnly(summary) {
+		return true, "rust use/mod 轻度冲突"
+	}
+	return false, "未命中 Rust 白名单冲突类型"
+}
+
+func (rustConflictProfile) ApplyRuleFix(repoDir, relPath string) (bool, error) {
+	if err := resolveRustDirectiveConflictFile(repoDir, relPath); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (rustConflictProfile) PromptAddon() string {
+	return strings.TrimSpace(`
+[Profile: Rust]
+- 仅做 use/mod 冲突并合，保持最小改动。
+- 保持 Rust 语法完整，不改函数签名与 trait 语义。
+- 禁止新增跨模块重构与非冲突区域修改。
+`)
+}
+
+func (rustConflictProfile) GateCommands(repoDir string, files []string, cfg PRConflictProfileConfig) ([]profileGateCommand, error) {
+	template := strings.TrimSpace(cfg.GateCommand)
+	if template == "" {
+		template = defaultRustProfileGateCommand
+	}
+	roots := collectProjectMarkerRoots(repoDir, files, "Cargo.toml")
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("未找到 Rust 项目根目录 Cargo.toml")
+	}
+
+	commands := make([]profileGateCommand, 0, len(roots))
+	for _, root := range roots {
+		manifest := "Cargo.toml"
+		pkgName, err := readCargoPackageName(filepath.Join(root, manifest))
+		if err != nil {
+			return nil, err
+		}
+		if templateContainsToken(template, "pkg") && strings.TrimSpace(pkgName) == "" {
+			return nil, fmt.Errorf("Rust gate 命令需要 {pkg}，但未解析到包名: %s", root)
+		}
+
+		command := renderGateCommandTemplate(template, map[string]string{
+			"pkg":      pkgName,
+			"path":     manifest,
+			"manifest": manifest,
+		})
+		if strings.TrimSpace(command) == "" {
+			continue
+		}
+		commands = append(commands, profileGateCommand{Dir: root, Command: command})
+	}
+	return commands, nil
+}
+
+func isElixirDirectiveConflictOnly(fileSummary conflictFileSummary) bool {
+	for _, block := range fileSummary.blocks {
+		if !isElixirDirectiveSide(block.ours) || !isElixirDirectiveSide(block.theirs) {
+			return false
+		}
+	}
+	return true
+}
+
+func isElixirDirectiveSide(side string) bool {
+	seen := 0
+	for _, line := range strings.Split(side, "\n") {
+		item, ok := normalizeElixirDirectiveItem(line)
+		if !ok {
+			return false
+		}
+		if item != "" {
+			seen++
+		}
+	}
+	return seen > 0
+}
+
+func normalizeElixirDirectiveItem(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return "", true
+	}
+	if strings.HasPrefix(trimmed, "#") {
+		return "", true
+	}
+	if idx := strings.Index(trimmed, "#"); idx >= 0 {
+		trimmed = strings.TrimSpace(trimmed[:idx])
+	}
+	if trimmed == "" {
+		return "", true
+	}
+	if strings.HasPrefix(trimmed, "alias ") || strings.HasPrefix(trimmed, "import ") || strings.HasPrefix(trimmed, "use ") {
+		return trimmed, true
+	}
+	return "", false
+}
+
+func isRustDirectiveConflictOnly(fileSummary conflictFileSummary) bool {
+	for _, block := range fileSummary.blocks {
+		if !isRustDirectiveSide(block.ours) || !isRustDirectiveSide(block.theirs) {
+			return false
+		}
+	}
+	return true
+}
+
+func isRustDirectiveSide(side string) bool {
+	seen := 0
+	for _, line := range strings.Split(side, "\n") {
+		item, ok := normalizeRustDirectiveItem(line)
+		if !ok {
+			return false
+		}
+		if item != "" {
+			seen++
+		}
+	}
+	return seen > 0
+}
+
+func normalizeRustDirectiveItem(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return "", true
+	}
+	if strings.HasPrefix(trimmed, "//") {
+		return "", true
+	}
+	if idx := strings.Index(trimmed, "//"); idx >= 0 {
+		trimmed = strings.TrimSpace(trimmed[:idx])
+	}
+	if trimmed == "" {
+		return "", true
+	}
+	if strings.HasPrefix(trimmed, "use ") || strings.HasPrefix(trimmed, "pub use ") || strings.HasPrefix(trimmed, "mod ") || strings.HasPrefix(trimmed, "pub mod ") {
+		return trimmed, true
+	}
+	return "", false
+}
+
+func resolveElixirDirectiveConflictFile(repoDir, relPath string) error {
+	return resolveDirectiveConflictFile(repoDir, relPath, normalizeElixirDirectiveItem, "elixir(alias/import/use)")
+}
+
+func resolveRustDirectiveConflictFile(repoDir, relPath string) error {
+	return resolveDirectiveConflictFile(repoDir, relPath, normalizeRustDirectiveItem, "rust(use/mod)")
+}
+
+func resolveDirectiveConflictFile(
+	repoDir string,
+	relPath string,
+	normalize func(string) (string, bool),
+	description string,
+) error {
+	absPath := filepath.Join(repoDir, relPath)
+	raw, err := os.ReadFile(absPath)
+	if err != nil {
+		return fmt.Errorf("读取冲突文件失败 %s: %w", relPath, err)
+	}
+
+	resolved, changed, err := resolveDirectiveConflictsInContent(string(raw), normalize, description)
+	if err != nil {
+		return fmt.Errorf("Rule 层处理文件 %s 失败: %w", relPath, err)
+	}
+	if !changed {
+		return fmt.Errorf("Rule 层未匹配 %s 冲突: %s", description, relPath)
+	}
+
+	mode := fileModeOrDefault(absPath, 0o644)
+	if err := os.WriteFile(absPath, []byte(resolved), mode); err != nil {
+		return fmt.Errorf("写回 Rule 结果失败 %s: %w", relPath, err)
+	}
+	if err := os.Chmod(absPath, mode); err != nil {
+		return fmt.Errorf("恢复 Rule 结果权限失败 %s: %w", relPath, err)
+	}
+	return nil
+}
+
+func resolveDirectiveConflictsInContent(
+	content string,
+	normalize func(string) (string, bool),
+	description string,
+) (string, bool, error) {
+	lines := strings.Split(content, "\n")
+	result := make([]string, 0, len(lines))
+	changed := false
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		if !strings.HasPrefix(line, "<<<<<<<") {
+			result = append(result, line)
+			continue
+		}
+
+		i++
+		var ours []string
+		for i < len(lines) && !strings.HasPrefix(lines[i], "=======") {
+			ours = append(ours, lines[i])
+			i++
+		}
+		if i >= len(lines) {
+			return "", false, fmt.Errorf("冲突块缺少 =======")
+		}
+
+		i++
+		var theirs []string
+		for i < len(lines) && !strings.HasPrefix(lines[i], ">>>>>>>") {
+			theirs = append(theirs, lines[i])
+			i++
+		}
+		if i >= len(lines) {
+			return "", false, fmt.Errorf("冲突块缺少 >>>>>>>")
+		}
+
+		merged, err := mergeDirectiveSides(ours, theirs, normalize, description)
+		if err != nil {
+			return "", false, err
+		}
+		result = append(result, merged...)
+		changed = true
+	}
+
+	return strings.Join(result, "\n"), changed, nil
+}
+
+func mergeDirectiveSides(
+	ours []string,
+	theirs []string,
+	normalize func(string) (string, bool),
+	description string,
+) ([]string, error) {
+	entries := make(map[string]struct{})
+	indent := ""
+
+	collect := func(lines []string) error {
+		for _, line := range lines {
+			if spaces := leadingWhitespace(line); spaces != "" {
+				indent = spaces
+			}
+			item, ok := normalize(line)
+			if !ok {
+				return fmt.Errorf("Rule 层仅支持 %s 轻度冲突，发现非白名单行: %q", description, strings.TrimSpace(line))
+			}
+			if item != "" {
+				entries[item] = struct{}{}
+			}
+		}
+		return nil
+	}
+
+	if err := collect(ours); err != nil {
+		return nil, err
+	}
+	if err := collect(theirs); err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("Rule 层未解析到有效 %s 项", description)
+	}
+
+	items := make([]string, 0, len(entries))
+	for item := range entries {
+		items = append(items, item)
+	}
+	sort.Strings(items)
+
+	merged := make([]string, 0, len(items))
+	for _, item := range items {
+		merged = append(merged, indent+item)
+	}
+	return merged, nil
+}
+
+func collectProjectMarkerRoots(repoDir string, files []string, marker string) []string {
+	seen := make(map[string]struct{})
+	roots := make([]string, 0)
+	for _, file := range files {
+		root := findProjectMarkerRoot(repoDir, file, marker)
+		if root == "" {
+			continue
+		}
+		if _, exists := seen[root]; exists {
+			continue
+		}
+		seen[root] = struct{}{}
+		roots = append(roots, root)
+	}
+	sort.Strings(roots)
+	return roots
+}
+
+func findProjectMarkerRoot(repoDir, relPath, marker string) string {
+	dir := filepath.Join(repoDir, filepath.Dir(relPath))
+	for {
+		if dir == "" || dir == "/" || dir == "." {
+			return ""
+		}
+		if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+			return dir
+		}
+		if samePath(dir, repoDir) {
+			return ""
+		}
+		next := filepath.Dir(dir)
+		if next == dir {
+			return ""
+		}
+		dir = next
+	}
+}
+
+func deriveElixirGateScope(root string, repoDir string, files []string) string {
+	candidates := make([]string, 0)
+	for _, file := range files {
+		abs := filepath.Join(repoDir, file)
+		rel, err := filepath.Rel(root, abs)
+		if err != nil {
+			continue
+		}
+		rel = filepath.ToSlash(rel)
+		if strings.HasPrefix(rel, "../") {
+			continue
+		}
+		if strings.HasPrefix(rel, "test/") && strings.HasSuffix(strings.ToLower(rel), ".exs") {
+			candidates = append(candidates, rel)
+		}
+	}
+	sort.Strings(candidates)
+	if len(candidates) == 0 {
+		return ""
+	}
+	return strings.Join(candidates, " ")
+}
+
+func readCargoPackageName(manifestPath string) (string, error) {
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return "", fmt.Errorf("读取 Cargo manifest 失败 %s: %w", manifestPath, err)
+	}
+
+	inPackage := false
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			inPackage = strings.EqualFold(trimmed, "[package]")
+			continue
+		}
+		if !inPackage {
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "name") {
+			continue
+		}
+		parts := strings.SplitN(trimmed, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		value := strings.TrimSpace(parts[1])
+		value = strings.Trim(value, "\"")
+		if value != "" {
+			return value, nil
+		}
+	}
+	return "", nil
+}

--- a/automation/niuma/pkg/control/conflict_profile_test.go
+++ b/automation/niuma/pkg/control/conflict_profile_test.go
@@ -1,0 +1,145 @@
+package control
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProfileRegistry_DetectBySuffix(t *testing.T) {
+	registry := defaultConflictProfileRegistry()
+
+	assert.Equal(t, conflictProfileGo, registry.DetectByFile(t.TempDir(), "pkg/a.go"))
+	assert.Equal(t, conflictProfileElixir, registry.DetectByFile(t.TempDir(), "lib/a.exs"))
+	assert.Equal(t, conflictProfileRust, registry.DetectByFile(t.TempDir(), "src/lib.rs"))
+	assert.Equal(t, conflictProfileUnknown, registry.DetectByFile(t.TempDir(), "docs/a.txt"))
+}
+
+func TestProfileRegistry_DetectByProjectMarkerFallback(t *testing.T) {
+	repoDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "nested", "doc"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "go.mod"), []byte("module example.com/test\n\ngo 1.22\n"), 0o644))
+
+	registry := defaultConflictProfileRegistry()
+	assert.Equal(t, conflictProfileGo, registry.DetectByFile(repoDir, filepath.ToSlash(filepath.Join("nested", "doc", "a.txt"))))
+}
+
+func TestGoProfileAllow_ThresholdBoundary(t *testing.T) {
+	profile := goConflictProfile{}
+	threshold := PRConflictThresholdConfig{MaxHunks: 3, MaxHunkLines: 15, MaxTotalLines: 50}
+
+	summaryAllow := conflictFileSummary{
+		hunks: 3,
+		blocks: []conflictBlock{
+			{ours: "\t\"fmt\"", theirs: "\t\"os\""},
+			{ours: "\t\"net/http\"", theirs: "\t\"strings\""},
+			{ours: "\t\"time\"", theirs: "\t\"context\""},
+		},
+	}
+	allowed, reason := profile.Allow("pkg/a.go", summaryAllow, threshold)
+	assert.True(t, allowed)
+	assert.Contains(t, reason, "import")
+
+	summaryRejectHunks := summaryAllow
+	summaryRejectHunks.hunks = 4
+	allowed, reason = profile.Allow("pkg/a.go", summaryRejectHunks, threshold)
+	assert.False(t, allowed)
+	assert.Contains(t, reason, "冲突块过多")
+
+	summaryRejectHunkLines := conflictFileSummary{
+		hunks: 1,
+		blocks: []conflictBlock{
+			{ours: strings.TrimSpace(buildProfileConflictLines(16)), theirs: "\t\"fmt\""},
+		},
+	}
+	allowed, reason = profile.Allow("pkg/a.go", summaryRejectHunkLines, threshold)
+	assert.False(t, allowed)
+	assert.Contains(t, reason, "单块冲突行数过多")
+
+	summaryRejectTotal := conflictFileSummary{
+		hunks: 3,
+		blocks: []conflictBlock{
+			{ours: buildProfileConflictLines(9), theirs: buildProfileConflictLines(9)},
+			{ours: buildProfileConflictLines(9), theirs: buildProfileConflictLines(9)},
+			{ours: buildProfileConflictLines(8), theirs: buildProfileConflictLines(8)},
+		},
+	}
+	allowed, reason = profile.Allow("pkg/a.go", summaryRejectTotal, threshold)
+	assert.False(t, allowed)
+	assert.Contains(t, reason, "冲突行数过多")
+}
+
+func TestBuildPRConflictAIPrompt_CommonAndProfileAddon(t *testing.T) {
+	repoDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "lib"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "lib", "a.exs"), []byte("ok"), 0o644))
+
+	ctrl := &Controller{}
+	group := conflictProfileGroup{
+		Name:    conflictProfileElixir,
+		Profile: elixirConflictProfile{},
+		Files:   []string{"lib/a.exs"},
+	}
+	summaries := map[string]conflictFileSummary{
+		"lib/a.exs": {
+			hunks: 1,
+			blocks: []conflictBlock{{
+				ours:   "alias Foo.Bar",
+				theirs: "alias Foo.Baz",
+			}},
+		},
+	}
+
+	prompt, err := ctrl.buildPRConflictAIPrompt(context.Background(), repoDir, group, summaries)
+	require.NoError(t, err)
+	assert.Contains(t, prompt, "Common 约束")
+	assert.Contains(t, prompt, "输出 schema")
+	assert.Contains(t, prompt, "[Profile: Elixir]")
+	assert.Contains(t, prompt, "### file: lib/a.exs")
+}
+
+func TestProfileGateCommands_RouteByLanguage(t *testing.T) {
+	repoDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "pkg"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "lib"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "test"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "src"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "go.mod"), []byte("module example.com/test\n\ngo 1.22\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "pkg", "a.go"), []byte("package pkg\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "mix.exs"), []byte("defmodule Demo.MixProject do\nend\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "test", "a_test.exs"), []byte("defmodule ATest do\nend\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "Cargo.toml"), []byte("[package]\nname = \"demo\"\nversion = \"0.1.0\"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "src", "lib.rs"), []byte("pub fn value() -> i32 { 1 }\n"), 0o644))
+
+	goCmds, err := goConflictProfile{}.GateCommands(repoDir, []string{"pkg/a.go"}, PRConflictProfileConfig{})
+	require.NoError(t, err)
+	require.NotEmpty(t, goCmds)
+	assert.Contains(t, goCmds[0].Command, "go test")
+
+	elixirCmds, err := elixirConflictProfile{}.GateCommands(repoDir, []string{"test/a_test.exs"}, PRConflictProfileConfig{})
+	require.NoError(t, err)
+	require.NotEmpty(t, elixirCmds)
+	assert.Contains(t, elixirCmds[0].Command, "mix test")
+
+	rustCmds, err := rustConflictProfile{}.GateCommands(repoDir, []string{"src/lib.rs"}, PRConflictProfileConfig{GateCommand: "cargo test -p {pkg}"})
+	require.NoError(t, err)
+	require.NotEmpty(t, rustCmds)
+	assert.Equal(t, "cargo test -p demo", rustCmds[0].Command)
+}
+
+func buildProfileConflictLines(lines int) string {
+	var b strings.Builder
+	for i := 0; i < lines; i++ {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(fmt.Sprintf("line_%d", i))
+	}
+	return b.String()
+}

--- a/automation/niuma/pkg/control/conflict_resolver.go
+++ b/automation/niuma/pkg/control/conflict_resolver.go
@@ -28,8 +28,13 @@ type prConflictAIEdit struct {
 	Content string `json:"content"`
 }
 
+type prConflictAIEditPayload struct {
+	Path    *string `json:"path"`
+	Content *string `json:"content"`
+}
+
 type prConflictAIResponse struct {
-	Edits []prConflictAIEdit `json:"edits"`
+	Edits []prConflictAIEditPayload `json:"edits"`
 }
 
 type fileSnapshot struct {
@@ -64,16 +69,63 @@ func (c *Controller) resolvePRConflictWithLayers(ctx context.Context, task Task,
 		return true, nil
 	}
 
-	if err := c.tryResolveConflictByRule(ctx, repoDir, conflictFiles); err == nil {
-		if err := c.stageConflictFiles(ctx, repoDir, conflictFiles); err != nil {
-			return false, err
+	registry := defaultConflictProfileRegistry()
+	groups, unknownFiles := groupConflictFilesByProfile(repoDir, conflictFiles, registry)
+	meta := conflictMetadataFromGroups(groups, conflictFiles)
+	if len(unknownFiles) > 0 {
+		return c.escalateConflictToHuman(
+			ctx,
+			task,
+			reviewStatus,
+			0,
+			fmt.Errorf("存在未知冲突文件类型: %s", strings.Join(unknownFiles, ", ")),
+			meta,
+		)
+	}
+
+	for _, group := range groups {
+		profileCfg := c.prConflictProfileConfig(group.Name)
+		if !profileCfg.Enabled {
+			return c.escalateConflictToHuman(
+				ctx,
+				task,
+				reviewStatus,
+				0,
+				fmt.Errorf("profile %s 已禁用: %s", group.Name, strings.Join(group.Files, ", ")),
+				meta,
+			)
 		}
-		if err := c.persistConflictResolutionMetadata(task, conflictResolutionLayerRule, 0, "", time.Time{}); err != nil {
-			return false, err
+	}
+
+	sessionSnapshot, err := c.capturePRConflictAttemptSnapshot(ctx, repoDir, conflictFiles, conflictFiles)
+	if err != nil {
+		return false, err
+	}
+	rollbackSessionWithCause := func(attempts int, cause error) (bool, error) {
+		rollbackErr := c.rollbackPRConflictAttempt(ctx, repoDir, sessionSnapshot)
+		return c.escalateConflictToHuman(ctx, task, reviewStatus, attempts, wrapConflictAttemptRollbackError(cause, rollbackErr), meta)
+	}
+
+	layer := conflictResolutionLayerRule
+	totalAIAttempts := 0
+	enteredAI := false
+
+	for _, group := range groups {
+		err := c.tryResolveConflictByRule(ctx, repoDir, conflictFiles, group)
+		if err == nil {
+			continue
 		}
-		return true, nil
-	} else {
-		if persistErr := c.persistConflictResolutionMetadata(task, conflictResolutionLayerRule, 0, err.Error(), time.Now().UTC()); persistErr != nil {
+
+		ruleMeta := meta
+		ruleMeta.ResolutionPath = conflictResolutionLayerRule
+		if persistErr := c.persistConflictResolutionMetadata(
+			task,
+			conflictResolutionLayerRule,
+			totalAIAttempts,
+			err.Error(),
+			time.Now().UTC(),
+			ruleMeta,
+		); persistErr != nil {
 			return false, persistErr
 		}
 		if commentErr := c.emitConflictLayerSwitchComment(
@@ -81,50 +133,76 @@ func (c *Controller) resolvePRConflictWithLayers(ctx context.Context, task Task,
 			task.IssueNum(),
 			reviewStatus.HeadSHA,
 			prConflictLayerStepRuleFail,
-			fmt.Sprintf("## ⚠️ Rule 层冲突修复失败\n\n- 层级: `rule`\n- 错误: `%s`", trimPRConflictError(err)),
+			fmt.Sprintf(
+				"## ⚠️ Rule 层冲突修复失败\n\n- profile: `%s`\n- 文件: `%s`\n- 错误: `%s`",
+				group.Name,
+				strings.Join(group.Files, ", "),
+				trimPRConflictError(err),
+			),
 		); commentErr != nil {
 			return false, commentErr
 		}
+
+		if !c.prConflictAIEnabled() {
+			return rollbackSessionWithCause(totalAIAttempts, fmt.Errorf("AI 层已禁用，Rule 层失败后升级人工"))
+		}
+		if allowed, reason := c.allowAIConflictResolution(group, summaries); !allowed {
+			return rollbackSessionWithCause(totalAIAttempts, fmt.Errorf("冲突超出 AI 安全边界: %s", reason))
+		}
+		if !enteredAI {
+			if commentErr := c.emitConflictLayerSwitchComment(
+				ctx,
+				task.IssueNum(),
+				reviewStatus.HeadSHA,
+				prConflictLayerStepAITry,
+				"## 🤖 进入 AI 层冲突修复\n\n- 层级切换: `rule-fail -> ai-try`\n- 将执行 Common Gate + Profile Gate",
+			); commentErr != nil {
+				return false, commentErr
+			}
+			enteredAI = true
+		}
+
+		layer = conflictResolutionLayerAI
+		resolvedByAI := false
+		var lastErr error
+		for attempt := 1; attempt <= c.prConflictAIMaxAttempts(); attempt++ {
+			totalAIAttempts++
+			err = c.tryResolveConflictByAIOnce(ctx, repoDir, conflictFiles, group, summaries)
+			if err == nil {
+				resolvedByAI = true
+				break
+			}
+
+			lastErr = err
+			aiMeta := meta
+			aiMeta.ResolutionPath = conflictResolutionLayerAI
+			if persistErr := c.persistConflictResolutionMetadata(
+				task,
+				conflictResolutionLayerAI,
+				totalAIAttempts,
+				err.Error(),
+				time.Now().UTC(),
+				aiMeta,
+			); persistErr != nil {
+				return false, persistErr
+			}
+		}
+		if !resolvedByAI {
+			return rollbackSessionWithCause(totalAIAttempts, lastErr)
+		}
 	}
 
-	if !c.prConflictAIEnabled() {
-		return c.escalateConflictToHuman(ctx, task, reviewStatus, 0, fmt.Errorf("AI 层已禁用，Rule 层失败后升级人工"))
-	}
-	if allowed, reason := c.allowAIConflictResolution(conflictFiles, summaries); !allowed {
-		return c.escalateConflictToHuman(ctx, task, reviewStatus, 0, fmt.Errorf("冲突超出 AI 安全边界: %s", reason))
+	if err := c.stageConflictFiles(ctx, repoDir, conflictFiles); err != nil {
+		rollbackErr := c.rollbackPRConflictAttempt(ctx, repoDir, sessionSnapshot)
+		return false, wrapConflictAttemptRollbackError(err, rollbackErr)
 	}
 
-	if err := c.emitConflictLayerSwitchComment(
-		ctx,
-		task.IssueNum(),
-		reviewStatus.HeadSHA,
-		prConflictLayerStepAITry,
-		"## 🤖 进入 AI 层冲突修复\n\n- 层级切换: `rule-fail -> ai-try`\n- 将执行统一门禁（结构/范围/质量）",
-	); err != nil {
+	meta.GatePassed = true
+	meta.ResolutionPath = layer
+	if err := c.persistConflictResolutionMetadata(task, layer, totalAIAttempts, "", time.Time{}, meta); err != nil {
 		return false, err
 	}
-
-	maxAttempts := c.prConflictAIMaxAttempts()
-	var lastErr error
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		err := c.tryResolveConflictByAIOnce(ctx, repoDir, conflictFiles, summaries)
-		if err == nil {
-			if err := c.stageConflictFiles(ctx, repoDir, conflictFiles); err != nil {
-				return false, err
-			}
-			if err := c.persistConflictResolutionMetadata(task, conflictResolutionLayerAI, attempt, "", time.Time{}); err != nil {
-				return false, err
-			}
-			return true, nil
-		}
-
-		lastErr = err
-		if persistErr := c.persistConflictResolutionMetadata(task, conflictResolutionLayerAI, attempt, err.Error(), time.Now().UTC()); persistErr != nil {
-			return false, persistErr
-		}
-	}
-
-	return c.escalateConflictToHuman(ctx, task, reviewStatus, maxAttempts, lastErr)
+	return true, nil
 }
 
 func (c *Controller) prConflictRepoDir() string {
@@ -153,12 +231,17 @@ func (c *Controller) collectPRConflictDetails(ctx context.Context, repoDir strin
 	return files, summaries, nil
 }
 
-func (c *Controller) tryResolveConflictByRule(ctx context.Context, repoDir string, conflictFiles []string) error {
-	if len(conflictFiles) == 0 {
+func (c *Controller) tryResolveConflictByRule(
+	ctx context.Context,
+	repoDir string,
+	allConflictFiles []string,
+	group conflictProfileGroup,
+) error {
+	if len(group.Files) == 0 {
 		return fmt.Errorf("无冲突文件")
 	}
 
-	attemptSnapshot, err := c.capturePRConflictAttemptSnapshot(ctx, repoDir, conflictFiles, conflictFiles)
+	attemptSnapshot, err := c.capturePRConflictAttemptSnapshot(ctx, repoDir, allConflictFiles, group.Files)
 	if err != nil {
 		return err
 	}
@@ -166,16 +249,17 @@ func (c *Controller) tryResolveConflictByRule(ctx context.Context, repoDir strin
 		return wrapConflictAttemptRollbackError(cause, c.rollbackPRConflictAttempt(ctx, repoDir, attemptSnapshot))
 	}
 
-	for _, file := range conflictFiles {
-		if strings.ToLower(filepath.Ext(file)) != ".go" {
-			return rollbackWithCause(fmt.Errorf("规则层仅支持 Go import 冲突，发现非 Go 文件: %s", file))
-		}
-		if err := resolveGoImportConflictFile(repoDir, file); err != nil {
+	for _, file := range group.Files {
+		changed, err := group.Profile.ApplyRuleFix(repoDir, file)
+		if err != nil {
 			return rollbackWithCause(err)
+		}
+		if !changed {
+			return rollbackWithCause(fmt.Errorf("Rule 层未修改文件: %s", file))
 		}
 	}
 
-	if err := c.runPRConflictGates(ctx, repoDir, conflictFiles); err != nil {
+	if err := c.runPRConflictGates(ctx, repoDir, allConflictFiles, group); err != nil {
 		return rollbackWithCause(err)
 	}
 	return nil
@@ -303,10 +387,18 @@ func leadingWhitespace(line string) string {
 	return ""
 }
 
-func (c *Controller) allowAIConflictResolution(conflictFiles []string, summaries map[string]conflictFileSummary) (bool, string) {
-	for _, file := range conflictFiles {
+func (c *Controller) prConflictProfileConfig(name string) PRConflictProfileConfig {
+	if c == nil || c.cfg == nil {
+		return lookupPRConflictProfileConfig(defaultPRConflictResolutionConfig(), name)
+	}
+	return lookupPRConflictProfileConfig(c.cfg.ConflictResolution, name)
+}
+
+func (c *Controller) allowAIConflictResolution(group conflictProfileGroup, summaries map[string]conflictFileSummary) (bool, string) {
+	profileCfg := c.prConflictProfileConfig(group.Name)
+	for _, file := range group.Files {
 		summary := summaries[file]
-		allowed, reason := isAIConflictWhitelisted(file, summary)
+		allowed, reason := group.Profile.Allow(file, summary, profileCfg.Threshold)
 		if !allowed {
 			return false, fmt.Sprintf("%s: %s", file, reason)
 		}
@@ -317,7 +409,8 @@ func (c *Controller) allowAIConflictResolution(conflictFiles []string, summaries
 func (c *Controller) tryResolveConflictByAIOnce(
 	ctx context.Context,
 	repoDir string,
-	conflictFiles []string,
+	allConflictFiles []string,
+	group conflictProfileGroup,
 	summaries map[string]conflictFileSummary,
 ) error {
 	provider := c.prConflictAIProvider()
@@ -325,7 +418,7 @@ func (c *Controller) tryResolveConflictByAIOnce(
 		return fmt.Errorf("AI provider 不可用")
 	}
 
-	prompt, err := c.buildPRConflictAIPrompt(ctx, repoDir, conflictFiles, summaries)
+	prompt, err := c.buildPRConflictAIPrompt(ctx, repoDir, group, summaries)
 	if err != nil {
 		return err
 	}
@@ -339,7 +432,12 @@ func (c *Controller) tryResolveConflictByAIOnce(
 	if err != nil {
 		return err
 	}
-	attemptSnapshot, err := c.capturePRConflictAttemptSnapshot(ctx, repoDir, conflictFiles, collectEditPaths(edits))
+	if err := validateProfileEditScope(group.Files, edits); err != nil {
+		return err
+	}
+
+	editedPaths := append(collectEditPaths(edits), group.Files...)
+	attemptSnapshot, err := c.capturePRConflictAttemptSnapshot(ctx, repoDir, allConflictFiles, editedPaths)
 	if err != nil {
 		return err
 	}
@@ -351,7 +449,7 @@ func (c *Controller) tryResolveConflictByAIOnce(
 		return rollbackWithCause(err)
 	}
 
-	if err := c.runPRConflictGates(ctx, repoDir, conflictFiles); err != nil {
+	if err := c.runPRConflictGates(ctx, repoDir, allConflictFiles, group); err != nil {
 		return rollbackWithCause(err)
 	}
 	return nil
@@ -376,13 +474,20 @@ func parsePRConflictAIEdits(resp string) ([]prConflictAIEdit, error) {
 
 	edits := make([]prConflictAIEdit, 0, len(payload.Edits))
 	for _, edit := range payload.Edits {
-		cleanPath, err := sanitizeEditPath(edit.Path)
+		if edit.Path == nil {
+			return nil, fmt.Errorf("AI 冲突修复响应缺少 path 字段")
+		}
+		if edit.Content == nil {
+			return nil, fmt.Errorf("AI 冲突修复响应缺少 content 字段: %s", strings.TrimSpace(*edit.Path))
+		}
+
+		cleanPath, err := sanitizeEditPath(*edit.Path)
 		if err != nil {
 			return nil, err
 		}
 		edits = append(edits, prConflictAIEdit{
 			Path:    cleanPath,
-			Content: edit.Content,
+			Content: *edit.Content,
 		})
 	}
 	return edits, nil
@@ -410,6 +515,20 @@ func collectEditPaths(edits []prConflictAIEdit) []string {
 		paths = append(paths, edit.Path)
 	}
 	return paths
+}
+
+func validateProfileEditScope(profileFiles []string, edits []prConflictAIEdit) error {
+	allowed := make(map[string]struct{}, len(profileFiles))
+	for _, file := range profileFiles {
+		allowed[file] = struct{}{}
+	}
+	for _, edit := range edits {
+		if _, ok := allowed[edit.Path]; ok {
+			continue
+		}
+		return fmt.Errorf("范围门禁失败: AI 输出越组修改 %s", edit.Path)
+	}
+	return nil
 }
 
 func captureFileSnapshots(repoDir string, files []string) (map[string]fileSnapshot, error) {
@@ -471,20 +590,47 @@ func applyPRConflictAIEdits(repoDir string, edits []prConflictAIEdit) error {
 	return nil
 }
 
-func (c *Controller) runPRConflictGates(ctx context.Context, repoDir string, conflictFiles []string) error {
-	if err := gateConflictMarkers(repoDir, conflictFiles); err != nil {
+func (c *Controller) runPRConflictGates(
+	ctx context.Context,
+	repoDir string,
+	allConflictFiles []string,
+	group conflictProfileGroup,
+) error {
+	if err := gateConflictMarkers(repoDir, group.Files); err != nil {
 		return err
 	}
-	if err := c.gateConflictGoTests(ctx, repoDir, conflictFiles); err != nil {
+	if err := c.gateChangedFileScope(ctx, repoDir, allConflictFiles); err != nil {
 		return err
 	}
+
+	profileCfg := c.prConflictProfileConfig(group.Name)
+	commands, err := group.Profile.GateCommands(repoDir, group.Files, profileCfg)
+	if err != nil {
+		return fmt.Errorf("profile gate 命令构建失败 (%s): %w", group.Name, err)
+	}
+	if err := c.runProfileGateCommands(ctx, group.Name, commands); err != nil {
+		return err
+	}
+
 	if smoke := c.prConflictSmokeTestCmd(); smoke != "" {
 		if _, err := c.runCommand(ctx, repoDir, "bash", "-lc", smoke); err != nil {
 			return fmt.Errorf("smoke tests 失败: %w", err)
 		}
 	}
-	if err := c.gateChangedFileScope(ctx, repoDir, conflictFiles); err != nil {
+	if err := c.gateChangedFileScope(ctx, repoDir, allConflictFiles); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (c *Controller) runProfileGateCommands(ctx context.Context, profileName string, commands []profileGateCommand) error {
+	for _, command := range commands {
+		if strings.TrimSpace(command.Command) == "" {
+			continue
+		}
+		if _, err := c.runCommand(ctx, command.Dir, "bash", "-lc", command.Command); err != nil {
+			return fmt.Errorf("质量门禁失败 [%s] (%s): %w", profileName, command.Command, err)
+		}
 	}
 	return nil
 }
@@ -827,19 +973,22 @@ func (c *Controller) stageConflictFiles(ctx context.Context, repoDir string, fil
 func (c *Controller) buildPRConflictAIPrompt(
 	ctx context.Context,
 	repoDir string,
-	conflictFiles []string,
+	group conflictProfileGroup,
 	summaries map[string]conflictFileSummary,
 ) (string, error) {
 	var sb strings.Builder
-	sb.WriteString("你是 Go 冲突修复助手。请仅返回 JSON，不要返回其他文本。\\n")
-	sb.WriteString("输出格式：{\"edits\":[{\"path\":\"<file>\",\"content\":\"<full file content>\"}]}\\n")
-	sb.WriteString("约束：\\n")
-	sb.WriteString("1) 仅允许修改下面给出的冲突文件；\\n")
-	sb.WriteString("2) 输出必须彻底移除冲突标记；\\n")
-	sb.WriteString("3) 保持最小改动，不改语义；\\n")
-	sb.WriteString("4) 仅输出 JSON。\\n\\n")
+	sb.WriteString("你是 Git 冲突修复助手。请仅返回 JSON，不要返回其他文本。\\n")
+	sb.WriteString("输出 schema：{\"edits\":[{\"path\":\"<file>\",\"content\":\"<full file content>\"}]}\\n")
+	sb.WriteString("Common 约束：\\n")
+	sb.WriteString("1) 仅允许修改当前 profile 的冲突文件；\\n")
+	sb.WriteString("2) 仅修改冲突块，不得越界修改无关区域；\\n")
+	sb.WriteString("3) 输出必须彻底移除冲突标记；\\n")
+	sb.WriteString("4) 保持最小改动，禁止跨文件重构；\\n")
+	sb.WriteString("5) 仅输出合法 JSON。\\n\\n")
+	sb.WriteString(group.Profile.PromptAddon())
+	sb.WriteString("\\n\\n")
 
-	for _, file := range conflictFiles {
+	for _, file := range group.Files {
 		raw, err := os.ReadFile(filepath.Join(repoDir, file))
 		if err != nil {
 			return "", fmt.Errorf("构造 AI prompt 读取文件失败 %s: %w", file, err)
@@ -873,6 +1022,7 @@ func (c *Controller) persistConflictResolutionMetadata(
 	attempts int,
 	lastErr string,
 	lastFailedAt time.Time,
+	ext ConflictResolutionMeta,
 ) error {
 	if c == nil || c.taskctl == nil || strings.TrimSpace(task.ID) == "" {
 		return nil
@@ -884,9 +1034,13 @@ func (c *Controller) persistConflictResolutionMetadata(
 	}
 
 	meta := map[string]string{
-		metaKeyConflictResolutionLayer:     strings.TrimSpace(layer),
-		metaKeyConflictResolutionAttempts:  strconv.Itoa(attempts),
-		metaKeyConflictResolutionLastError: trimmedLastErr,
+		metaKeyConflictResolutionLayer:      strings.TrimSpace(layer),
+		metaKeyConflictResolutionAttempts:   strconv.Itoa(attempts),
+		metaKeyConflictResolutionProfile:    strings.TrimSpace(ext.Profile),
+		metaKeyConflictResolutionFiles:      formatConflictFileList(ext.Files),
+		metaKeyConflictResolutionLastError:  trimmedLastErr,
+		metaKeyConflictResolutionGatePassed: strconv.FormatBool(ext.GatePassed),
+		metaKeyConflictResolutionPath:       strings.TrimSpace(ext.ResolutionPath),
 	}
 	if lastFailedAt.IsZero() {
 		meta[metaKeyConflictResolutionLastFailedAt] = ""
@@ -932,9 +1086,12 @@ func (c *Controller) escalateConflictToHuman(
 	reviewStatus PRReviewStatus,
 	attempts int,
 	cause error,
+	meta ConflictResolutionMeta,
 ) (bool, error) {
 	now := time.Now().UTC()
-	if err := c.persistConflictResolutionMetadata(task, conflictResolutionLayerHuman, attempts, trimPRConflictError(cause), now); err != nil {
+	meta.GatePassed = false
+	meta.ResolutionPath = conflictResolutionLayerHuman
+	if err := c.persistConflictResolutionMetadata(task, conflictResolutionLayerHuman, attempts, trimPRConflictError(cause), now, meta); err != nil {
 		return true, err
 	}
 

--- a/automation/niuma/pkg/control/conflict_resolver_test.go
+++ b/automation/niuma/pkg/control/conflict_resolver_test.go
@@ -102,9 +102,15 @@ func Value() int { return 2 }
 		},
 	}
 
-	err := ctrl.tryResolveConflictByAIOnce(context.Background(), dir, []string{"pkg.go"}, summaries)
+	err := ctrl.tryResolveConflictByAIOnce(
+		context.Background(),
+		dir,
+		[]string{"pkg.go"},
+		conflictProfileGroup{Name: conflictProfileGo, Profile: goConflictProfile{}, Files: []string{"pkg.go"}},
+		summaries,
+	)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "out of scope")
+	assert.Contains(t, err.Error(), "范围门禁失败")
 
 	readme, readErr := os.ReadFile(filepath.Join(dir, "README.md"))
 	require.NoError(t, readErr)
@@ -138,11 +144,12 @@ func TestGateChangedFileScope_RejectsUntrackedFiles(t *testing.T) {
 
 func TestRunPRConflictGates_SmokeSideEffectsBlockedByScopeGate(t *testing.T) {
 	dir := setupGitRepo(t)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "conflict.txt"), []byte("resolved\n"), 0o644))
-	runGit(t, dir, "add", "conflict.txt")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/conflict\n\ngo 1.22\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "conflict.go"), []byte("package conflict\n\nfunc Value() int { return 1 }\n"), 0o644))
+	runGit(t, dir, "add", ".")
 	runGit(t, dir, "commit", "-m", "add conflict file")
 
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "conflict.txt"), []byte("resolved by gate\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "conflict.go"), []byte("package conflict\n\nfunc Value() int { return 2 }\n"), 0o644))
 	ctrl := &Controller{
 		cfg: &ControlConfig{
 			RepoDir:                dir,
@@ -150,7 +157,12 @@ func TestRunPRConflictGates_SmokeSideEffectsBlockedByScopeGate(t *testing.T) {
 		},
 	}
 
-	err := ctrl.runPRConflictGates(context.Background(), dir, []string{"conflict.txt"})
+	err := ctrl.runPRConflictGates(
+		context.Background(),
+		dir,
+		[]string{"conflict.go"},
+		conflictProfileGroup{Name: conflictProfileGo, Profile: goConflictProfile{}, Files: []string{"conflict.go"}},
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "changed files out of scope")
 	assert.Contains(t, err.Error(), "smoke-side-effect.txt")
@@ -182,7 +194,13 @@ func TestTryResolveConflictByAIOnce_RollbackOnGoTestSideEffects(t *testing.T) {
 		},
 	}
 
-	err := ctrl.tryResolveConflictByAIOnce(context.Background(), dir, []string{conflictFile}, summaries)
+	err := ctrl.tryResolveConflictByAIOnce(
+		context.Background(),
+		dir,
+		[]string{conflictFile},
+		conflictProfileGroup{Name: conflictProfileGo, Profile: goConflictProfile{}, Files: []string{conflictFile}},
+		summaries,
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "质量门禁失败")
 
@@ -203,7 +221,19 @@ func TestPersistConflictResolutionMetadata_WritesAllFields(t *testing.T) {
 	task := Task{ID: "task-1", Metadata: map[string]string{"issue_num": "321"}}
 
 	failedAt := time.Date(2026, 2, 19, 10, 0, 0, 0, time.UTC)
-	err := ctrl.persistConflictResolutionMetadata(task, conflictResolutionLayerAI, 2, "gate failed", failedAt)
+	err := ctrl.persistConflictResolutionMetadata(
+		task,
+		conflictResolutionLayerAI,
+		2,
+		"gate failed",
+		failedAt,
+		ConflictResolutionMeta{
+			Profile:        "go",
+			Files:          []string{"pkg.go"},
+			GatePassed:     false,
+			ResolutionPath: conflictResolutionLayerAI,
+		},
+	)
 	require.NoError(t, err)
 
 	raw, readErr := os.ReadFile(logPath)
@@ -217,6 +247,13 @@ func TestPersistConflictResolutionMetadata_WritesAllFields(t *testing.T) {
 	assert.Contains(t, text, "gate failed")
 	assert.Contains(t, text, metaKeyConflictResolutionLastFailedAt)
 	assert.Contains(t, text, failedAt.Format(time.RFC3339))
+	assert.Contains(t, text, metaKeyConflictResolutionProfile)
+	assert.Contains(t, text, "go")
+	assert.Contains(t, text, metaKeyConflictResolutionFiles)
+	assert.Contains(t, text, "pkg.go")
+	assert.Contains(t, text, metaKeyConflictResolutionGatePassed)
+	assert.Contains(t, text, "false")
+	assert.Contains(t, text, metaKeyConflictResolutionPath)
 }
 
 func setupPRConflictRepoWithFailingGoTestSideEffects(t *testing.T) (string, string) {

--- a/automation/niuma/pkg/control/controller.go
+++ b/automation/niuma/pkg/control/controller.go
@@ -193,6 +193,7 @@ type ControlConfig struct {
 	PRConflictEnableAI         bool
 	PRConflictAIMaxAttempts    int
 	PRConflictSmokeTestCmd     string
+	ConflictResolution         PRConflictResolutionConfig
 	RepoDir                    string           `yaml:"-"`
 	IssueLockTTL               time.Duration    `yaml:"-"`
 	IssueLockHeartbeatInterval time.Duration    `yaml:"-"`
@@ -221,6 +222,7 @@ func DefaultControlConfig() *ControlConfig {
 		PRConflictUnknownBackoffs:  append([]time.Duration(nil), defaultPRConflictUnknownBackoffs...),
 		PRConflictEnableAI:         true,
 		PRConflictAIMaxAttempts:    prConflictAIDefaultMaxAttempts,
+		ConflictResolution:         defaultPRConflictResolutionConfig(),
 		RepoDir:                    ".",
 		IssueLockTTL:               issueLockDefaultTTL,
 		IssueLockHeartbeatInterval: issueLockDefaultHeartbeat,
@@ -263,6 +265,7 @@ func NewController(
 	if cfg.PRConflictAIMaxAttempts <= 0 {
 		cfg.PRConflictAIMaxAttempts = prConflictAIDefaultMaxAttempts
 	}
+	cfg.ConflictResolution = normalizePRConflictResolutionConfig(cfg.ConflictResolution)
 	if cfg.IssueLockTTL <= 0 {
 		cfg.IssueLockTTL = issueLockDefaultTTL
 	}

--- a/automation/niuma/pkg/control/controller_test.go
+++ b/automation/niuma/pkg/control/controller_test.go
@@ -2743,6 +2743,67 @@ func TestReconcilePRReviewableConflicts_AIDisabledEscalatesHuman(t *testing.T) {
 	assert.Contains(t, logText, "AI 层已禁用")
 }
 
+func TestReconcilePRReviewableConflicts_ProfileDisabledEscalatesHuman(t *testing.T) {
+	dir, _ := setupPRConflictTestHelperRepo(t)
+	taskctlClient, logPath := newRecordingTaskCtlClient(t)
+
+	mockGH := newMockGitHubOps(
+		IssueInfo{
+			Number: 321,
+			Body:   "profile disabled body",
+			Labels: []string{"bot:pr-reviewable"},
+		},
+	)
+	mockGH.resolvePRReviewStatus[321] = PRReviewStatus{
+		PRNum:            123,
+		HeadSHA:          "sha-profile-disabled",
+		Mergeable:        PRMergeableConflicting,
+		MergeStateStatus: "DIRTY",
+	}
+
+	ctrl := &Controller{
+		github:  mockGH,
+		taskctl: taskctlClient,
+		cfg: &ControlConfig{
+			RepoDir:                   dir,
+			PRConflictEnableAI:        true,
+			PRConflictAIMaxAttempts:   2,
+			PRConflictRetryThreshold:  3,
+			PRConflictUnknownBackoffs: []time.Duration{time.Millisecond},
+			ConflictResolution: PRConflictResolutionConfig{
+				Profiles: map[string]PRConflictProfileConfig{
+					"go": {
+						Enabled: false,
+						Threshold: PRConflictThresholdConfig{
+							MaxHunks:      3,
+							MaxHunkLines:  15,
+							MaxTotalLines: 50,
+						},
+					},
+				},
+			},
+		},
+	}
+	tasks := []Task{{ID: "task-321", Metadata: map[string]string{"issue_num": "321"}}}
+	issueByNumber := map[int]IssueInfo{
+		321: {Number: 321, Labels: []string{"bot:pr-reviewable"}},
+	}
+
+	err := ctrl.reconcilePRReviewableConflicts(context.Background(), tasks, issueByNumber)
+	require.NoError(t, err)
+
+	labels, labelsErr := mockGH.ListLabels(context.Background(), 321)
+	require.NoError(t, labelsErr)
+	assert.Contains(t, labels, needsHumanLabel)
+
+	rawLog, logErr := os.ReadFile(logPath)
+	require.NoError(t, logErr)
+	logText := string(rawLog)
+	assert.Contains(t, logText, metaKeyConflictResolutionProfile)
+	assert.Contains(t, logText, "go")
+	assert.Contains(t, logText, "profile go 已禁用")
+}
+
 func TestNewController_PRConflictAIMaxAttemptsDefaultsWhenNonPositive(t *testing.T) {
 	cfgZero := &ControlConfig{
 		RepoDir:                 ".",
@@ -2761,6 +2822,22 @@ func TestNewController_PRConflictAIMaxAttemptsDefaultsWhenNonPositive(t *testing
 	ctrlNegative := NewController(nil, nil, nil, nil, cfgNegative)
 	assert.Equal(t, prConflictAIDefaultMaxAttempts, cfgNegative.PRConflictAIMaxAttempts)
 	assert.Equal(t, prConflictAIDefaultMaxAttempts, ctrlNegative.prConflictAIMaxAttempts())
+}
+
+func TestNewController_ConflictResolutionProfilesDefaultEnabled(t *testing.T) {
+	cfg := &ControlConfig{RepoDir: "."}
+	ctrl := NewController(nil, nil, nil, nil, cfg)
+
+	goCfg := ctrl.prConflictProfileConfig("go")
+	elixirCfg := ctrl.prConflictProfileConfig("elixir")
+	rustCfg := ctrl.prConflictProfileConfig("rust")
+
+	assert.True(t, goCfg.Enabled)
+	assert.True(t, elixirCfg.Enabled)
+	assert.True(t, rustCfg.Enabled)
+	assert.Equal(t, 3, goCfg.Threshold.MaxHunks)
+	assert.Equal(t, 15, goCfg.Threshold.MaxHunkLines)
+	assert.Equal(t, 50, goCfg.Threshold.MaxTotalLines)
 }
 
 func TestShouldEnqueueIntegrationMergeTask_UsesLatestIssueLabel(t *testing.T) {

--- a/automation/niuma/pkg/control/integration.go
+++ b/automation/niuma/pkg/control/integration.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -19,6 +20,8 @@ type IntegrationBuilder struct {
 	repoDir    string
 	baseBranch string
 }
+
+var gateTemplateTokenPattern = regexp.MustCompile(`\{([a-z_]+)\}`)
 
 const (
 	// integrationMergeExecutorVersion 用于记录执行器版本，便于审计与回溯。
@@ -610,6 +613,23 @@ func splitNonEmptyLines(s string) []string {
 		}
 	}
 	return lines
+}
+
+func renderGateCommandTemplate(template string, vars map[string]string) string {
+	template = strings.TrimSpace(template)
+	if template == "" {
+		return ""
+	}
+	rendered := gateTemplateTokenPattern.ReplaceAllStringFunc(template, func(token string) string {
+		key := strings.Trim(token, "{}")
+		return strings.TrimSpace(vars[key])
+	})
+	return strings.Join(strings.Fields(rendered), " ")
+}
+
+func templateContainsToken(template string, key string) bool {
+	token := fmt.Sprintf("{%s}", strings.TrimSpace(key))
+	return strings.Contains(template, token)
 }
 
 // Reset 从 master 重建 integration 分支（冲突无法解决时）

--- a/automation/niuma/pkg/control/types.go
+++ b/automation/niuma/pkg/control/types.go
@@ -11,8 +11,12 @@ const (
 	// 冲突修复可观测性 metadata 键。
 	metaKeyConflictResolutionLayer        = "conflict_resolution_layer"
 	metaKeyConflictResolutionAttempts     = "conflict_resolution_attempts"
+	metaKeyConflictResolutionProfile      = "conflict_resolution_profile"
+	metaKeyConflictResolutionFiles        = "conflict_resolution_files"
 	metaKeyConflictResolutionLastError    = "conflict_resolution_last_error"
 	metaKeyConflictResolutionLastFailedAt = "conflict_resolution_last_failed_at"
+	metaKeyConflictResolutionGatePassed   = "gate_passed"
+	metaKeyConflictResolutionPath         = "resolution_path"
 )
 
 const (
@@ -21,6 +25,33 @@ const (
 	conflictResolutionLayerAI    = "ai"
 	conflictResolutionLayerHuman = "human"
 )
+
+// PRConflictThresholdConfig 表示冲突自动修复阈值配置。
+type PRConflictThresholdConfig struct {
+	MaxHunks      int `json:"max_hunks" yaml:"max_hunks"`
+	MaxHunkLines  int `json:"max_hunk_lines" yaml:"max_hunk_lines"`
+	MaxTotalLines int `json:"max_total_lines" yaml:"max_total_lines"`
+}
+
+// PRConflictProfileConfig 表示单个语言 profile 的配置。
+type PRConflictProfileConfig struct {
+	Enabled     bool                      `json:"enabled" yaml:"enabled"`
+	GateCommand string                    `json:"gate_command" yaml:"gate_command"`
+	Threshold   PRConflictThresholdConfig `json:"threshold" yaml:"threshold"`
+}
+
+// PRConflictResolutionConfig 表示冲突修复 profile 总配置。
+type PRConflictResolutionConfig struct {
+	Profiles map[string]PRConflictProfileConfig `json:"profiles" yaml:"profiles"`
+}
+
+// ConflictResolutionMeta 表示冲突修复 metadata 扩展字段。
+type ConflictResolutionMeta struct {
+	Profile        string
+	Files          []string
+	GatePassed     bool
+	ResolutionPath string
+}
 
 // TaskStatus 任务状态
 type TaskStatus string


### PR DESCRIPTION
Closes #344

## Summary

## ✅ 最终方案：feat(workflow): 冲突修复 Profile 化（Common + Go/Elixir/Rust）V1 实现方案

### 实现方案

1) 架构重构：新增 ConflictProfile 抽象与注册表，主流程保持 Rule -> AI -> Human 不变，仅把语言相关逻辑下沉到 profile。ConflictProfile 最小契约包含：识别能力（Detect）、白名单判定（Allow）、Rule 修复（ApplyRuleFix）、Prompt 追加段（PromptAddon）、门禁命令生成（GateCommands）。
2) 识别与路由：按“后缀优先、目录标记兜底”识别 profile。P0 后缀映射：.go->go, .ex/.exs->elixir, .rs->rust；P1 目录标记：go.mod/mix.exs/Cargo.toml。未知文件标记 unknown，禁止进入 AI，直接升级 human。多文件冲突按 profile 分组串行执行，每组独立 Rule/AI，但共享 Common Gate 与统一回滚事务。
3) Prompt 两段式：固定 Common Prompt（输入格式、JSON 输出 schema、仅改冲突区、最小改动、禁止越界）+ Profile Prompt（语言语法/风格/禁止项）。输出 JSON 严格校验，缺字段或越界直接失败并回滚。
4) Rule 插件化（V1 低风险白名单）：
- Go：沿用现有 import 冲突自动合并。
- Elixir：仅处理 alias/import/use 轻度冲突（重排、去重、简单合并）。
- Rust：仅处理 use/mod 轻度冲突（重排、去重、简单合并）。
统一阈值默认：单文件 hunks<=3、单 hunk 行数<=15、总冲突行数<=50；超过阈值直接升级 human（N 允许，N+1 拒绝）。
5) 门禁体系：先跑 Common Gate（结构合法性、范围门禁、只改冲突文件），再跑 Profile Gate。命令模板可配置：Go `go test {pkg}`，Elixir `mix test {scope}`，Rust `cargo test -p {pkg}` 或 `cargo test --manifest-path {path}`。任一失败触发统一回滚并记录 last_error。
6) 配置与可观测性：新增 conflict_resolution.profiles 配置（enabled、gate_command、阈值覆盖），默认 go/elixir/rust 开启。metadata 新增 conflict_resolution_profile（单值或分组摘要）、conflict_resolution_files、conflict_resolution_last_error、gate_passed、resolution_path(rule/ai/human)。
7) 兼容与回滚策略：保留 go 现有行为作为基线；新 profile 可按配置独立关闭。识别失败/门禁失败/越界修改统一降级 human，确保安全优先。

### 文件变更

| 路径 | 操作 | 描述 |
|------|------|------|
| `automation/niuma/pkg/control/conflict_profile.go` | add | 新增 ConflictProfile 接口、ProfileRegistry、后缀/目录识别逻辑、默认 go/elixir/rust 注册实现骨架。 |
| `automation/niuma/pkg/control/types.go` | modify | 新增 profile 配置结构、阈值配置、ConflictResolutionMeta 字段（profile/files/last_error/gate_passed/resolution_path）。 |
| `automation/niuma/pkg/control/conflict_resolver.go` | modify | 主流程改为按 profile 分组处理；接入 Rule 插件、AI 两段式 Prompt、Common Gate + Profile Gate、统一回滚。 |
| `automation/niuma/pkg/control/integration.go` | modify | 门禁执行器支持 profile 命令模板渲染与路由，失败归因标准化。 |
| `automation/niuma/pkg/control/conflict_profile_test.go` | add | 新增 profile 识别、白名单阈值 N/N+1、Prompt 拼装、门禁路由单元测试。 |
| `automation/niuma/pkg/control/conflict_resolver_test.go` | modify | 补充多 profile 分组、未知后缀降级 human、越界回滚与 metadata 断言。 |
| `automation/niuma/pkg/control/controller_test.go` | modify | 覆盖 pr-reviewable 下 go/elixir/rust 路径与失败升级 human 行为。 |
| `automation/niuma/cmd/niuma/control.go` | modify | 暴露/透传 profile 相关配置与开关，保持现有命令入口兼容。 |
| `automation/niuma/README.md` | modify | 文档化 profile 架构、配置示例、门禁命令模板、失败回滚语义与排障。 |

### 测试场景

1. **后缀识别-go**: 输入 `conflict file: pkg/a.go` → 预期 `profile=go，允许进入 go Rule/AI 路径。`
2. **后缀识别-elixir**: 输入 `conflict file: lib/a.exs` → 预期 `profile=elixir，使用 elixir Prompt 与 mix test 门禁。`
3. **后缀识别-rust**: 输入 `conflict file: src/lib.rs` → 预期 `profile=rust，使用 rust Prompt 与 cargo test 门禁。`
4. **未知后缀降级**: 输入 `conflict file: docs/a.txt` → 预期 `profile=unknown，拒绝 AI，直接升级 human。`
5. **阈值边界-允许**: 输入 `hunks=3, hunk_lines_max=15, total_lines=50` → 预期 `允许自动修复流程继续。`
6. **阈值边界-拒绝**: 输入 `hunks=4 或 hunk_lines_max=16 或 total_lines=51` → 预期 `拒绝自动修复并升级 human。`
7. **越界修改拦截**: 输入 `AI 输出 edits 包含未冲突文件` → 预期 `范围门禁失败，回滚，写入 last_error。`
8. **混合语言分组**: 输入 `同批次冲突文件：a.go + b.rs` → 预期 `按组串行处理并共享 Common Gate，任一组失败整体回滚。`


---
*方案已定稿，即将开始实现。*
<!-- PLAN_FILES:[{"path":"automation/niuma/pkg/control/conflict_profile.go","action":"add","description":"新增 ConflictProfile 接口、ProfileRegistry、后缀/目录识别逻辑、默认 go/elixir/rust 注册实现骨架。"},{"path":"automation/niuma/pkg/control/types.go","action":"modify","description":"新增 profile 配置结构、阈值配置、ConflictResolutionMeta 字段（profile/files/last_error/gate_passed/resolution_path）。"},{"path":"automation/niuma/pkg/control/conflict_resolver.go","action":"modify","description":"主流程改为按 profile 分组处理；接入 Rule 插件、AI 两段式 Prompt、Common Gate + Profile Gate、统一回滚。"},{"path":"automation/niuma/pkg/control/integration.go","action":"modify","description":"门禁执行器支持 profile 命令模板渲染与路由，失败归因标准化。"},{"path":"automation/niuma/pkg/control/conflict_profile_test.go","action":"add","description":"新增 profile 识别、白名单阈值 N/N+1、Prompt 拼装、门禁路由单元测试。"},{"path":"automation/niuma/pkg/control/conflict_resolver_test.go","action":"modify","description":"补充多 profile 分组、未知后缀降级 human、越界回滚与 metadata 断言。"},{"path":"automation/niuma/pkg/control/controller_test.go","action":"modify","description":"覆盖 pr-reviewable 下 go/elixir/rust 路径与失败升级 human 行为。"},{"path":"automation/niuma/cmd/niuma/control.go","action":"modify","description":"暴露/透传 profile 相关配置与开关，保持现有命令入口兼容。"},{"path":"automation/niuma/README.md","action":"modify","description":"文档化 profile 架构、配置示例、门禁命令模板、失败回滚语义与排障。"}] -->