### PR TITLE
fix: refactor: 将 implement/iterate 的 gate 重试+升级逻辑下沉到 niuma gate run 子命令 (#358)

### DIFF
--- a/.github/workflows/niuma-implement.yml
+++ b/.github/workflows/niuma-implement.yml
@@ -57,112 +57,18 @@ jobs:
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
       - name: Run PR Gate
-        id: gate
         if: steps.find_pr.outputs.pr_number != ''
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
-          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
-        run: |
-          ./.github/scripts/niuma-test-gate.sh "$PR_NUMBER"
-
-      - name: Resolve Gate Retry Policy
-        id: gate_policy
-        if: steps.gate.outcome == 'failure'
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          WORKSPACE: ${{ github.workspace }}
-          NIUMA_INTEGRATION_GATE_MAX_RETRIES: ${{ vars.NIUMA_INTEGRATION_GATE_MAX_RETRIES || '2' }}
-        run: |
-          STORE_PATH="$WORKSPACE/.niuma/tasks.json"
-          MAX_RETRIES="$NIUMA_INTEGRATION_GATE_MAX_RETRIES"
-          if ! [[ "$MAX_RETRIES" =~ ^[0-9]+$ ]]; then
-            MAX_RETRIES=2
-          fi
-
-          RETRY_COUNT=0
-          GATE_STATUS=""
-          ATTEMPT_KEY=""
-          ESCALATION_LABELED="false"
-          if [ -f "$STORE_PATH" ]; then
-            RETRY_COUNT=$(jq -r --arg issue "$ISSUE_NUMBER" '
-              map(select(.metadata.issue_num == $issue)) | first | .metadata.integration_gate_retry_count // "0"
-            ' "$STORE_PATH")
-            GATE_STATUS=$(jq -r --arg issue "$ISSUE_NUMBER" '
-              map(select(.metadata.issue_num == $issue)) | first | .metadata.integration_gate_status // ""
-            ' "$STORE_PATH")
-            ATTEMPT_KEY=$(jq -r --arg issue "$ISSUE_NUMBER" '
-              map(select(.metadata.issue_num == $issue)) | first | .metadata.integration_gate_attempt_key // ""
-            ' "$STORE_PATH")
-            ESCALATION_LABELED=$(jq -r --arg issue "$ISSUE_NUMBER" '
-              map(select(.metadata.issue_num == $issue)) | first | .metadata.integration_gate_escalation_labeled // "false"
-            ' "$STORE_PATH")
-          fi
-
-          if ! [[ "$RETRY_COUNT" =~ ^[0-9]+$ ]]; then
-            RETRY_COUNT=0
-          fi
-          if [ "$ESCALATION_LABELED" != "true" ]; then
-            ESCALATION_LABELED="false"
-          fi
-
-          SHOULD_AUTO_FIX=true
-          if [ "$GATE_STATUS" = "escalated" ] || [ "$RETRY_COUNT" -gt "$MAX_RETRIES" ]; then
-            SHOULD_AUTO_FIX=false
-          fi
-
-          echo "max_retries=$MAX_RETRIES" >> "$GITHUB_OUTPUT"
-          echo "retry_count=$RETRY_COUNT" >> "$GITHUB_OUTPUT"
-          echo "gate_status=$GATE_STATUS" >> "$GITHUB_OUTPUT"
-          echo "attempt_key=$ATTEMPT_KEY" >> "$GITHUB_OUTPUT"
-          echo "escalation_labeled=$ESCALATION_LABELED" >> "$GITHUB_OUTPUT"
-          echo "should_auto_fix=$SHOULD_AUTO_FIX" >> "$GITHUB_OUTPUT"
-
-      - name: Mark Needs Fix On Gate Failure
-        if: steps.gate.outcome == 'failure' && steps.gate_policy.outputs.should_auto_fix == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
           REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+          WORKSPACE: ${{ github.workspace }}
+          NIUMA_INTEGRATION_GATE_MAX_RETRIES: ${{ vars.NIUMA_INTEGRATION_GATE_MAX_RETRIES || '2' }}
         run: |
-          "$NIUMA_BIN" state-label set \
+          "$NIUMA_BIN" gate run \
             --repo "$REPO" \
             --issue "$ISSUE_NUMBER" \
-            --from bot:pr-created \
-            --to bot:pr-needs-fix || \
-          "$NIUMA_BIN" state-label set \
-            --repo "$REPO" \
-            --issue "$ISSUE_NUMBER" \
-            --to bot:pr-needs-fix
-          gh issue comment "$ISSUE_NUMBER" --body "## ❌ Gate 未通过\n\n实现后自动测试门禁失败，已回退为 \`bot:pr-needs-fix\`，请继续迭代修复。\n\n- retry_count=${{ steps.gate_policy.outputs.retry_count }}\n- max_retries=${{ steps.gate_policy.outputs.max_retries }}\n- attempt_key=\`${{ steps.gate_policy.outputs.attempt_key }}\`"
-          exit 1
-
-      - name: Escalate Human On Gate Failure
-        if: steps.gate.outcome == 'failure' && steps.gate_policy.outputs.should_auto_fix != 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          ATTEMPT_KEY="${{ steps.gate_policy.outputs.attempt_key }}"
-          ESCALATION_LABELED="${{ steps.gate_policy.outputs.escalation_labeled }}"
-          if [ -n "$ATTEMPT_KEY" ]; then
-            MARKER="<!-- NIUMA_GATE_ESCALATED:${ATTEMPT_KEY} -->"
-          else
-            MARKER="<!-- NIUMA_GATE_ESCALATED:no-attempt-key -->"
-          fi
-
-          if [ "$ESCALATION_LABELED" = "true" ]; then
-            echo "controller 已完成 gate 升级标记，同轮次跳过重复升级动作。"
-            exit 1
-          fi
-
-          EXISTING_COUNT=$(gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments?per_page=100" | \
-            jq -r --arg marker "$MARKER" '[.[] | select(.body | contains($marker))] | length')
-          if [ "$EXISTING_COUNT" -gt 0 ]; then
-            echo "发现同 attempt_key 升级记录，跳过重复升级动作。"
-            exit 1
-          fi
-
-          gh issue edit "$ISSUE_NUMBER" --add-label needs-human --add-label integration-gate-failed
-          gh issue comment "$ISSUE_NUMBER" --body "## 🚨 Gate 已超限，升级人工处理\n\nintegration gate 失败次数已超过上限，本轮不再触发自动修复。\n\n- retry_count=${{ steps.gate_policy.outputs.retry_count }}\n- max_retries=${{ steps.gate_policy.outputs.max_retries }}\n- attempt_key=\`${{ steps.gate_policy.outputs.attempt_key }}\`\n\n$MARKER"
-          exit 1
+            --pr "$PR_NUMBER" \
+            --repo-dir "$WORKSPACE" \
+            --max-retries "$NIUMA_INTEGRATION_GATE_MAX_RETRIES"

--- a/.github/workflows/niuma-iterate.yml
+++ b/.github/workflows/niuma-iterate.yml
@@ -90,33 +90,21 @@ jobs:
             --repo-dir "$WORKSPACE"
 
       - name: Run PR Gate
-        id: gate
         if: steps.find_pr.outputs.pr_number != '' && steps.pr_state.outputs.pr_state == 'OPEN'
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
-          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
-        run: |
-          ./.github/scripts/niuma-test-gate.sh "$PR_NUMBER"
-
-      - name: Keep Needs-Fix On Gate Failure
-        if: steps.gate.outcome == 'failure'
         env:
           GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
           REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+          WORKSPACE: ${{ github.workspace }}
+          NIUMA_INTEGRATION_GATE_MAX_RETRIES: ${{ vars.NIUMA_INTEGRATION_GATE_MAX_RETRIES || '2' }}
         run: |
-          "$NIUMA_BIN" state-label set \
+          "$NIUMA_BIN" gate run \
             --repo "$REPO" \
             --issue "$ISSUE_NUMBER" \
-            --from bot:pr-created \
-            --to bot:pr-needs-fix || \
-          "$NIUMA_BIN" state-label set \
-            --repo "$REPO" \
-            --issue "$ISSUE_NUMBER" \
-            --to bot:pr-needs-fix
-          gh issue comment "$ISSUE_NUMBER" --body "## ❌ Gate 未通过\n\n迭代后自动测试门禁失败，状态保持为 \`bot:pr-needs-fix\`，请继续修复。"
-          exit 1
+            --pr "$PR_NUMBER" \
+            --repo-dir "$WORKSPACE" \
+            --max-retries "$NIUMA_INTEGRATION_GATE_MAX_RETRIES"
 
   # 人工 PR review changes_requested → 迭代
   iterate-from-human:
@@ -171,30 +159,18 @@ jobs:
             --repo-dir "$WORKSPACE"
 
       - name: Run PR Gate
-        id: gate_human
         if: steps.extract.outputs.issue_number != ''
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
-          PR_NUMBER: ${{ steps.extract.outputs.pr_number }}
-        run: |
-          ./.github/scripts/niuma-test-gate.sh "$PR_NUMBER"
-
-      - name: Keep Needs-Fix On Gate Failure
-        if: steps.gate_human.outcome == 'failure'
         env:
           GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
           REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ steps.extract.outputs.issue_number }}
+          PR_NUMBER: ${{ steps.extract.outputs.pr_number }}
+          WORKSPACE: ${{ github.workspace }}
+          NIUMA_INTEGRATION_GATE_MAX_RETRIES: ${{ vars.NIUMA_INTEGRATION_GATE_MAX_RETRIES || '2' }}
         run: |
-          "$NIUMA_BIN" state-label set \
+          "$NIUMA_BIN" gate run \
             --repo "$REPO" \
             --issue "$ISSUE_NUMBER" \
-            --from bot:pr-created \
-            --to bot:pr-needs-fix || \
-          "$NIUMA_BIN" state-label set \
-            --repo "$REPO" \
-            --issue "$ISSUE_NUMBER" \
-            --to bot:pr-needs-fix
-          gh issue comment "$ISSUE_NUMBER" --body "## ❌ Gate 未通过\n\n根据人工 review 迭代后门禁失败，状态保持为 \`bot:pr-needs-fix\`，请继续修复。"
-          exit 1
+            --pr "$PR_NUMBER" \
+            --repo-dir "$WORKSPACE" \
+            --max-retries "$NIUMA_INTEGRATION_GATE_MAX_RETRIES"

--- a/automation/niuma/cmd/niuma/gate_run.go
+++ b/automation/niuma/cmd/niuma/gate_run.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/biantaishabi2/Cli/automation/niuma/pkg/gate"
+	gh "github.com/biantaishabi2/Cli/automation/niuma/pkg/github"
+	"github.com/biantaishabi2/Cli/automation/niuma/pkg/state"
+	"github.com/spf13/cobra"
+)
+
+var gateCmd = &cobra.Command{
+	Use:   "gate",
+	Short: "PR gate 相关命令",
+}
+
+var gateRunCmd = &cobra.Command{
+	Use:   "run",
+	Short: "执行 PR gate 并处理重试/升级",
+	RunE:  runGateRun,
+}
+
+var flagGateMaxRetries int
+
+func init() {
+	gateCmd.AddCommand(gateRunCmd)
+	gateRunCmd.Flags().IntVar(&flagGateMaxRetries, "max-retries", 2, "gate 自动修复最大重试次数")
+}
+
+func runGateRun(cmd *cobra.Command, args []string) error {
+	if flagRepo == "" || flagIssue == 0 || flagPR == 0 {
+		return fmt.Errorf("必须指定 --repo、--issue 和 --pr")
+	}
+	if flagGateMaxRetries < 0 {
+		return fmt.Errorf("--max-retries 不能小于 0")
+	}
+
+	repoDir := "."
+	if flagRepoDir != "" {
+		repoDir = flagRepoDir
+	}
+
+	ctx := context.Background()
+	client, err := gh.NewClientFromEnv(flagRepo)
+	if err != nil {
+		return err
+	}
+
+	runner, err := gate.NewRunner(gate.Options{
+		Repo:       flagRepo,
+		Issue:      flagIssue,
+		PR:         flagPR,
+		RepoDir:    repoDir,
+		MaxRetries: flagGateMaxRetries,
+		MarkNeedsFix: func(ctx context.Context, repo string, issue int) error {
+			return markIssueNeedsFix(ctx, client, issue)
+		},
+		AddLabels: func(ctx context.Context, repo string, issue int, labels []string) error {
+			for _, label := range labels {
+				if err := client.AddLabel(ctx, issue, label); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		AddComment: func(ctx context.Context, repo string, issue int, body string) error {
+			_, err := client.AddComment(ctx, issue, body)
+			return err
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	result, err := runner.Run(ctx)
+	if err == nil {
+		fmt.Printf("gate 通过: issue=%d pr=%d\n", flagIssue, flagPR)
+		return nil
+	}
+
+	if errors.Is(err, gate.ErrGateFailed) {
+		fmt.Printf(
+			"gate 未通过: issue=%d pr=%d retry_count=%d max_retries=%d attempt_key=%s escalated=%t dedup=%t\n",
+			flagIssue,
+			flagPR,
+			result.RetryCount,
+			result.MaxRetries,
+			result.AttemptKey,
+			result.Escalated,
+			result.EscalationCommentSkipped,
+		)
+		return withExitCode(1, err)
+	}
+	return err
+}
+
+func markIssueNeedsFix(ctx context.Context, client *gh.Client, issue int) error {
+	if err := state.TransitionWithRetry(ctx, client, issue, state.StatePRCreated, state.StatePRNeedsFix, nil); err != nil {
+		return state.TransitionWithRetry(ctx, client, issue, "", state.StatePRNeedsFix, nil)
+	}
+	return nil
+}

--- a/automation/niuma/cmd/niuma/main.go
+++ b/automation/niuma/cmd/niuma/main.go
@@ -98,6 +98,7 @@ func init() {
 	rootCmd.AddCommand(reviewCmd)
 	rootCmd.AddCommand(controlCmd)
 	rootCmd.AddCommand(stateLabelCmd)
+	rootCmd.AddCommand(gateCmd)
 
 	// discuss 特有 flags
 	discussCmd.Flags().IntVar(&flagMaxDiscussionRounds, "max-discussion-rounds", 0, "讨论最大轮次（1-20，0 表示使用配置）")

--- a/automation/niuma/cmd/niuma/workflow_contract_test.go
+++ b/automation/niuma/cmd/niuma/workflow_contract_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,6 +73,21 @@ func TestWorkflowContract_DispatchCompletedHasPayloadAndDegradePolicy(t *testing
 	assert.Contains(t, content, "event_source: \"close-after-integration-merge\"")
 	assert.Contains(t, content, "event_id")
 	assert.Contains(t, content, "Warn Dispatch Failure")
+}
+
+func TestWorkflowContract_ImplementGateUsesUnifiedCommand(t *testing.T) {
+	content := loadWorkflowFile(t, "niuma-implement.yml")
+
+	assert.Contains(t, content, "\"$NIUMA_BIN\" gate run")
+	assert.NotContains(t, content, "Resolve Gate Retry Policy")
+	assert.NotContains(t, content, "Escalate Human On Gate Failure")
+}
+
+func TestWorkflowContract_IterateGateUsesUnifiedCommand(t *testing.T) {
+	content := loadWorkflowFile(t, "niuma-iterate.yml")
+
+	assert.Equal(t, 2, strings.Count(content, "\"$NIUMA_BIN\" gate run"))
+	assert.NotContains(t, content, "Keep Needs-Fix On Gate Failure")
 }
 
 func loadWorkflowFile(t *testing.T, workflowName string) string {

--- a/automation/niuma/pkg/gate/gate.go
+++ b/automation/niuma/pkg/gate/gate.go
@@ -1,0 +1,435 @@
+package gate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	metaKeyIssueNum                 = "issue_num"
+	metaKeyGateStatus               = "integration_gate_status"
+	metaKeyGateRetryCount           = "integration_gate_retry_count"
+	metaKeyGateLastError            = "integration_gate_last_error"
+	metaKeyGateLastCheckedAt        = "integration_gate_last_checked_at"
+	metaKeyGateAttemptKey           = "integration_gate_attempt_key"
+	metaKeyLastEscalatedAttemptKey  = "last_escalated_attempt_key"
+	gateStatusRetrying              = "retrying"
+	gateStatusEscalated             = "escalated"
+	maxGateErrorMessageLen          = 800
+	needsHumanLabel                 = "needs-human"
+	integrationGateFailedLabel      = "integration-gate-failed"
+	defaultGateScriptRelativePath   = ".github/scripts/niuma-test-gate.sh"
+	defaultNeedsFixCommentTemplate  = "## ❌ Gate 未通过\n\n自动测试门禁失败，已回退为 `bot:pr-needs-fix`，请继续迭代修复。\n\n- retry_count=%d\n- max_retries=%d\n- attempt_key=`%s`"
+	defaultEscalatedCommentTemplate = "## 🚨 Gate 已超限，升级人工处理\n\nintegration gate 失败次数已超过上限，本轮不再触发自动修复。\n\n- retry_count=%d\n- max_retries=%d\n- attempt_key=`%s`"
+)
+
+var ErrGateFailed = errors.New("gate failed")
+
+type RunGateFunc func(ctx context.Context, repoDir string, pr int) (string, error)
+type MarkNeedsFixFunc func(ctx context.Context, repo string, issue int) error
+type AddLabelsFunc func(ctx context.Context, repo string, issue int, labels []string) error
+type AddCommentFunc func(ctx context.Context, repo string, issue int, body string) error
+
+type Options struct {
+	Repo       string
+	Issue      int
+	PR         int
+	RepoDir    string
+	MaxRetries int
+
+	Now          func() time.Time
+	RunGate      RunGateFunc
+	MarkNeedsFix MarkNeedsFixFunc
+	AddLabels    AddLabelsFunc
+	AddComment   AddCommentFunc
+}
+
+type Runner struct {
+	opts Options
+}
+
+type Result struct {
+	Passed                   bool
+	RetryCount               int
+	MaxRetries               int
+	AttemptKey               string
+	Escalated                bool
+	EscalationCommentSkipped bool
+	StatePersisted           bool
+}
+
+func NewRunner(opts Options) (*Runner, error) {
+	if strings.TrimSpace(opts.Repo) == "" {
+		return nil, fmt.Errorf("repo 不能为空")
+	}
+	if opts.Issue <= 0 {
+		return nil, fmt.Errorf("issue 必须大于 0")
+	}
+	if opts.PR <= 0 {
+		return nil, fmt.Errorf("pr 必须大于 0")
+	}
+	if opts.MaxRetries < 0 {
+		return nil, fmt.Errorf("max_retries 不能小于 0")
+	}
+	if opts.RepoDir == "" {
+		opts.RepoDir = "."
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	if opts.RunGate == nil {
+		opts.RunGate = runGateScript
+	}
+	if opts.MarkNeedsFix == nil {
+		return nil, fmt.Errorf("MarkNeedsFix 未配置")
+	}
+	if opts.AddLabels == nil {
+		return nil, fmt.Errorf("AddLabels 未配置")
+	}
+	if opts.AddComment == nil {
+		return nil, fmt.Errorf("AddComment 未配置")
+	}
+	return &Runner{opts: opts}, nil
+}
+
+func (r *Runner) Run(ctx context.Context) (Result, error) {
+	result := Result{MaxRetries: r.opts.MaxRetries}
+
+	gateOutput, gateErr := r.opts.RunGate(ctx, r.opts.RepoDir, r.opts.PR)
+	if gateErr == nil {
+		result.Passed = true
+		return result, nil
+	}
+
+	attemptKey := buildAttemptKey(r.opts.Issue, r.opts.PR, r.opts.Now())
+	storePath := filepath.Join(r.opts.RepoDir, ".niuma", "tasks.json")
+	store, err := loadTaskStore(storePath, r.opts.Issue)
+	if err != nil {
+		return result, fmt.Errorf("读取 tasks.json 失败: %w", err)
+	}
+
+	retryCount := 1
+	lastEscalatedAttemptKey := ""
+	if store.hasMatchedTask() {
+		retryCount = parseNonNegativeInt(store.metadata[metaKeyGateRetryCount]) + 1
+		lastEscalatedAttemptKey = parseString(store.metadata[metaKeyLastEscalatedAttemptKey])
+	}
+
+	result.RetryCount = retryCount
+	result.AttemptKey = attemptKey
+
+	status := gateStatusRetrying
+	if retryCount > r.opts.MaxRetries {
+		status = gateStatusEscalated
+		result.Escalated = true
+	}
+
+	if store.hasMatchedTask() {
+		store.metadata[metaKeyGateStatus] = status
+		store.metadata[metaKeyGateRetryCount] = strconv.Itoa(retryCount)
+		store.metadata[metaKeyGateAttemptKey] = attemptKey
+		store.metadata[metaKeyGateLastCheckedAt] = r.opts.Now().UTC().Format(time.RFC3339)
+		store.metadata[metaKeyGateLastError] = trimGateError(gateOutput, gateErr)
+		if err := store.save(); err != nil {
+			return result, fmt.Errorf("写入 tasks.json 失败: %w", err)
+		}
+		result.StatePersisted = true
+	}
+
+	if !result.Escalated {
+		if err := r.opts.MarkNeedsFix(ctx, r.opts.Repo, r.opts.Issue); err != nil {
+			return result, fmt.Errorf("%w: gate 失败后设置 bot:pr-needs-fix 失败: %v", ErrGateFailed, err)
+		}
+		commentBody := fmt.Sprintf(defaultNeedsFixCommentTemplate, retryCount, r.opts.MaxRetries, attemptKey)
+		if err := r.opts.AddComment(ctx, r.opts.Repo, r.opts.Issue, commentBody); err != nil {
+			return result, fmt.Errorf("%w: gate 失败评论发布失败: %v", ErrGateFailed, err)
+		}
+		return result, fmt.Errorf("%w: %s", ErrGateFailed, trimGateError(gateOutput, gateErr))
+	}
+
+	if err := r.opts.AddLabels(ctx, r.opts.Repo, r.opts.Issue, []string{needsHumanLabel, integrationGateFailedLabel}); err != nil {
+		return result, fmt.Errorf("%w: gate 超限后打标失败: %v", ErrGateFailed, err)
+	}
+
+	if lastEscalatedAttemptKey == attemptKey {
+		result.EscalationCommentSkipped = true
+		return result, fmt.Errorf("%w: %s", ErrGateFailed, trimGateError(gateOutput, gateErr))
+	}
+
+	escalatedComment := fmt.Sprintf(defaultEscalatedCommentTemplate, retryCount, r.opts.MaxRetries, attemptKey)
+	if err := r.opts.AddComment(ctx, r.opts.Repo, r.opts.Issue, escalatedComment); err != nil {
+		return result, fmt.Errorf("%w: gate 超限升级评论发布失败: %v", ErrGateFailed, err)
+	}
+
+	if store.hasMatchedTask() {
+		store.metadata[metaKeyLastEscalatedAttemptKey] = attemptKey
+		if err := store.save(); err != nil {
+			return result, fmt.Errorf("写入 last_escalated_attempt_key 失败: %w", err)
+		}
+		result.StatePersisted = true
+	}
+
+	return result, fmt.Errorf("%w: %s", ErrGateFailed, trimGateError(gateOutput, gateErr))
+}
+
+func runGateScript(ctx context.Context, repoDir string, pr int) (string, error) {
+	scriptPath := filepath.Join(repoDir, defaultGateScriptRelativePath)
+	cmd := exec.CommandContext(ctx, scriptPath, strconv.Itoa(pr))
+	cmd.Dir = repoDir
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func buildAttemptKey(issue, pr int, now time.Time) string {
+	return fmt.Sprintf("issue-%d-pr-%d-%s", issue, pr, now.UTC().Format("20060102"))
+}
+
+func trimGateError(output string, runErr error) string {
+	parts := make([]string, 0, 2)
+	trimmedOutput := strings.TrimSpace(output)
+	trimmedErr := ""
+	if runErr != nil {
+		trimmedErr = strings.TrimSpace(runErr.Error())
+	}
+
+	if trimmedOutput != "" {
+		parts = append(parts, trimmedOutput)
+	}
+	if trimmedErr != "" && (trimmedOutput == "" || !strings.Contains(trimmedOutput, trimmedErr)) {
+		parts = append(parts, trimmedErr)
+	}
+	joined := strings.TrimSpace(strings.Join(parts, " | "))
+	if joined == "" {
+		joined = "gate 命令失败"
+	}
+	if len(joined) <= maxGateErrorMessageLen {
+		return joined
+	}
+	return joined[:maxGateErrorMessageLen]
+}
+
+type taskStore struct {
+	path     string
+	root     any
+	metadata map[string]any
+}
+
+func loadTaskStore(path string, issue int) (*taskStore, error) {
+	store := &taskStore{path: path}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return store, nil
+		}
+		return nil, err
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return store, nil
+	}
+
+	var root any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, err
+	}
+
+	store.root = root
+	store.metadata = findTaskMetadataByIssue(root, issue)
+	return store, nil
+}
+
+func (s *taskStore) hasMatchedTask() bool {
+	return s != nil && s.root != nil && s.metadata != nil
+}
+
+func (s *taskStore) save() error {
+	if !s.hasMatchedTask() {
+		return nil
+	}
+	payload, err := json.MarshalIndent(s.root, "", "  ")
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	return writeAtomicJSON(s.path, payload)
+}
+
+func findTaskMetadataByIssue(root any, issue int) map[string]any {
+	switch typed := root.(type) {
+	case []any:
+		for _, item := range typed {
+			task, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if taskIssueNum(task) != issue {
+				continue
+			}
+			return ensureTaskMetadata(task)
+		}
+	case map[string]any:
+		if taskIssueNum(typed) == issue {
+			return ensureTaskMetadata(typed)
+		}
+		tasksObj, ok := typed["tasks"]
+		if !ok {
+			return nil
+		}
+		switch tasksTyped := tasksObj.(type) {
+		case map[string]any:
+			for _, value := range tasksTyped {
+				task, ok := value.(map[string]any)
+				if !ok {
+					continue
+				}
+				if taskIssueNum(task) != issue {
+					continue
+				}
+				return ensureTaskMetadata(task)
+			}
+		case []any:
+			for _, value := range tasksTyped {
+				task, ok := value.(map[string]any)
+				if !ok {
+					continue
+				}
+				if taskIssueNum(task) != issue {
+					continue
+				}
+				return ensureTaskMetadata(task)
+			}
+		}
+	}
+	return nil
+}
+
+func taskIssueNum(task map[string]any) int {
+	if task == nil {
+		return 0
+	}
+	meta := taskMetadata(task)
+	if meta != nil {
+		if issue := parseNonNegativeInt(meta[metaKeyIssueNum]); issue > 0 {
+			return issue
+		}
+	}
+	return parseNonNegativeInt(task[metaKeyIssueNum])
+}
+
+func taskMetadata(task map[string]any) map[string]any {
+	if task == nil {
+		return nil
+	}
+	existing, ok := task["metadata"]
+	if !ok || existing == nil {
+		return nil
+	}
+	if metadata, ok := existing.(map[string]any); ok {
+		return metadata
+	}
+	if metadata, ok := existing.(map[string]string); ok {
+		converted := make(map[string]any, len(metadata))
+		for k, v := range metadata {
+			converted[k] = v
+		}
+		return converted
+	}
+	return nil
+}
+
+func ensureTaskMetadata(task map[string]any) map[string]any {
+	if task == nil {
+		return nil
+	}
+
+	existing := taskMetadata(task)
+	if existing == nil {
+		meta := map[string]any{}
+		task["metadata"] = meta
+		return meta
+	}
+	task["metadata"] = existing
+	return existing
+}
+
+func parseNonNegativeInt(v any) int {
+	switch typed := v.(type) {
+	case nil:
+		return 0
+	case int:
+		if typed < 0 {
+			return 0
+		}
+		return typed
+	case int64:
+		if typed < 0 {
+			return 0
+		}
+		return int(typed)
+	case float64:
+		if typed < 0 {
+			return 0
+		}
+		return int(typed)
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed == "" {
+			return 0
+		}
+		parsed, err := strconv.Atoi(trimmed)
+		if err != nil || parsed < 0 {
+			return 0
+		}
+		return parsed
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil || parsed < 0 {
+			return 0
+		}
+		return int(parsed)
+	default:
+		return 0
+	}
+}
+
+func parseString(v any) string {
+	switch typed := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(typed)
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	}
+}
+
+func writeAtomicJSON(path string, payload []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmpPath := path + ".tmp"
+	file, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(payload); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/automation/niuma/pkg/gate/gate_test.go
+++ b/automation/niuma/pkg/gate/gate_test.go
@@ -1,0 +1,370 @@
+package gate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunner_PassDoesNotMutateState(t *testing.T) {
+	repoDir := t.TempDir()
+	storePath := writeTaskStore(t, repoDir, 358, map[string]string{
+		metaKeyGateRetryCount: "1",
+		metaKeyGateStatus:     gateStatusRetrying,
+	})
+
+	markCalled := 0
+	labelCalled := 0
+	commentCalled := 0
+
+	runner := newRunnerForTest(t, Options{
+		Repo:       "biantaishabi2/Cli",
+		Issue:      358,
+		PR:         9001,
+		RepoDir:    repoDir,
+		MaxRetries: 2,
+		Now:        fixedNow,
+		RunGate: func(context.Context, string, int) (string, error) {
+			return "ok", nil
+		},
+		MarkNeedsFix: func(context.Context, string, int) error {
+			markCalled++
+			return nil
+		},
+		AddLabels: func(context.Context, string, int, []string) error {
+			labelCalled++
+			return nil
+		},
+		AddComment: func(context.Context, string, int, string) error {
+			commentCalled++
+			return nil
+		},
+	})
+
+	result, err := runner.Run(context.Background())
+	require.NoError(t, err)
+	assert.True(t, result.Passed)
+	assert.Equal(t, 0, markCalled)
+	assert.Equal(t, 0, labelCalled)
+	assert.Equal(t, 0, commentCalled)
+
+	meta := readIssueMetadata(t, storePath, 358)
+	assert.Equal(t, "1", meta[metaKeyGateRetryCount])
+	assert.Equal(t, gateStatusRetrying, meta[metaKeyGateStatus])
+}
+
+func TestRunner_FirstFailureMarksNeedsFix(t *testing.T) {
+	repoDir := t.TempDir()
+	storePath := writeTaskStore(t, repoDir, 358, map[string]string{
+		metaKeyGateRetryCount: "0",
+	})
+
+	markCalled := 0
+	labelCalled := 0
+	comments := make([]string, 0, 1)
+
+	runner := newRunnerForTest(t, Options{
+		Repo:       "biantaishabi2/Cli",
+		Issue:      358,
+		PR:         9010,
+		RepoDir:    repoDir,
+		MaxRetries: 2,
+		Now:        fixedNow,
+		RunGate: func(context.Context, string, int) (string, error) {
+			return "go test failed", errors.New("exit status 1")
+		},
+		MarkNeedsFix: func(context.Context, string, int) error {
+			markCalled++
+			return nil
+		},
+		AddLabels: func(context.Context, string, int, []string) error {
+			labelCalled++
+			return nil
+		},
+		AddComment: func(_ context.Context, _ string, _ int, body string) error {
+			comments = append(comments, body)
+			return nil
+		},
+	})
+
+	result, err := runner.Run(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGateFailed)
+	assert.False(t, result.Passed)
+	assert.False(t, result.Escalated)
+	assert.Equal(t, "issue-358-pr-9010-20260219", result.AttemptKey)
+	assert.Equal(t, 1, result.RetryCount)
+	assert.Equal(t, 1, markCalled)
+	assert.Equal(t, 0, labelCalled)
+	require.Len(t, comments, 1)
+	assert.Contains(t, comments[0], "retry_count=1")
+	assert.Contains(t, comments[0], "max_retries=2")
+	assert.Contains(t, comments[0], "issue-358-pr-9010-20260219")
+
+	meta := readIssueMetadata(t, storePath, 358)
+	assert.Equal(t, "1", meta[metaKeyGateRetryCount])
+	assert.Equal(t, gateStatusRetrying, meta[metaKeyGateStatus])
+	assert.Equal(t, "issue-358-pr-9010-20260219", meta[metaKeyGateAttemptKey])
+}
+
+func TestRunner_ExceedRetriesEscalates(t *testing.T) {
+	repoDir := t.TempDir()
+	storePath := writeTaskStore(t, repoDir, 358, map[string]string{
+		metaKeyGateRetryCount: "2",
+	})
+
+	markCalled := 0
+	labels := make([][]string, 0, 1)
+	comments := make([]string, 0, 1)
+
+	runner := newRunnerForTest(t, Options{
+		Repo:       "biantaishabi2/Cli",
+		Issue:      358,
+		PR:         9011,
+		RepoDir:    repoDir,
+		MaxRetries: 2,
+		Now:        fixedNow,
+		RunGate: func(context.Context, string, int) (string, error) {
+			return "gate failed", errors.New("exit status 1")
+		},
+		MarkNeedsFix: func(context.Context, string, int) error {
+			markCalled++
+			return nil
+		},
+		AddLabels: func(_ context.Context, _ string, _ int, set []string) error {
+			labels = append(labels, append([]string(nil), set...))
+			return nil
+		},
+		AddComment: func(_ context.Context, _ string, _ int, body string) error {
+			comments = append(comments, body)
+			return nil
+		},
+	})
+
+	result, err := runner.Run(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGateFailed)
+	assert.True(t, result.Escalated)
+	assert.Equal(t, 3, result.RetryCount)
+	assert.Equal(t, 0, markCalled)
+	require.Len(t, labels, 1)
+	assert.Equal(t, []string{needsHumanLabel, integrationGateFailedLabel}, labels[0])
+	require.Len(t, comments, 1)
+	assert.Contains(t, comments[0], "retry_count=3")
+	assert.Contains(t, comments[0], "issue-358-pr-9011-20260219")
+
+	meta := readIssueMetadata(t, storePath, 358)
+	assert.Equal(t, "3", meta[metaKeyGateRetryCount])
+	assert.Equal(t, gateStatusEscalated, meta[metaKeyGateStatus])
+	assert.Equal(t, "issue-358-pr-9011-20260219", meta[metaKeyLastEscalatedAttemptKey])
+}
+
+func TestRunner_DedupEscalationCommentByAttemptKey(t *testing.T) {
+	repoDir := t.TempDir()
+	storePath := writeTaskStore(t, repoDir, 358, map[string]string{
+		metaKeyGateRetryCount:          "3",
+		metaKeyLastEscalatedAttemptKey: "issue-358-pr-9012-20260219",
+	})
+
+	labels := 0
+	comments := 0
+
+	runner := newRunnerForTest(t, Options{
+		Repo:       "biantaishabi2/Cli",
+		Issue:      358,
+		PR:         9012,
+		RepoDir:    repoDir,
+		MaxRetries: 2,
+		Now:        fixedNow,
+		RunGate: func(context.Context, string, int) (string, error) {
+			return "gate failed", errors.New("exit status 1")
+		},
+		MarkNeedsFix: func(context.Context, string, int) error { return nil },
+		AddLabels: func(context.Context, string, int, []string) error {
+			labels++
+			return nil
+		},
+		AddComment: func(context.Context, string, int, string) error {
+			comments++
+			return nil
+		},
+	})
+
+	result, err := runner.Run(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGateFailed)
+	assert.True(t, result.Escalated)
+	assert.True(t, result.EscalationCommentSkipped)
+	assert.Equal(t, 4, result.RetryCount)
+	assert.Equal(t, 1, labels)
+	assert.Equal(t, 0, comments)
+
+	meta := readIssueMetadata(t, storePath, 358)
+	assert.Equal(t, "4", meta[metaKeyGateRetryCount])
+	assert.Equal(t, gateStatusEscalated, meta[metaKeyGateStatus])
+	assert.Equal(t, "issue-358-pr-9012-20260219", meta[metaKeyLastEscalatedAttemptKey])
+}
+
+func TestRunner_BackwardCompatibleObjectStoreFormat(t *testing.T) {
+	repoDir := t.TempDir()
+	storePath := writeObjectTaskStore(t, repoDir, 358)
+
+	runner := newRunnerForTest(t, Options{
+		Repo:       "biantaishabi2/Cli",
+		Issue:      358,
+		PR:         9020,
+		RepoDir:    repoDir,
+		MaxRetries: 2,
+		Now:        fixedNow,
+		RunGate: func(context.Context, string, int) (string, error) {
+			return "gate failed", errors.New("exit status 1")
+		},
+		MarkNeedsFix: func(context.Context, string, int) error { return nil },
+		AddLabels:    func(context.Context, string, int, []string) error { return nil },
+		AddComment:   func(context.Context, string, int, string) error { return nil },
+	})
+
+	result, err := runner.Run(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGateFailed)
+	assert.Equal(t, 1, result.RetryCount)
+
+	meta := readIssueMetadataFromObjectStore(t, storePath, 358)
+	assert.Equal(t, "1", meta[metaKeyGateRetryCount])
+	assert.Equal(t, gateStatusRetrying, meta[metaKeyGateStatus])
+	assert.Equal(t, "issue-358-pr-9020-20260219", meta[metaKeyGateAttemptKey])
+}
+
+func newRunnerForTest(t *testing.T, opts Options) *Runner {
+	t.Helper()
+	runner, err := NewRunner(opts)
+	require.NoError(t, err)
+	return runner
+}
+
+func fixedNow() time.Time {
+	return time.Date(2026, 2, 19, 12, 0, 0, 0, time.UTC)
+}
+
+func writeTaskStore(t *testing.T, repoDir string, issue int, extraMetadata map[string]string) string {
+	t.Helper()
+
+	storePath := filepath.Join(repoDir, ".niuma", "tasks.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(storePath), 0o755))
+
+	metadata := map[string]any{
+		metaKeyIssueNum: strconv.Itoa(issue),
+	}
+	for k, v := range extraMetadata {
+		metadata[k] = v
+	}
+
+	payload := []map[string]any{
+		{
+			"id":       "task-358",
+			"subject":  "issue 358",
+			"status":   "in-progress",
+			"metadata": metadata,
+		},
+	}
+	raw, err := json.MarshalIndent(payload, "", "  ")
+	require.NoError(t, err)
+	raw = append(raw, '\n')
+	require.NoError(t, os.WriteFile(storePath, raw, 0o644))
+	return storePath
+}
+
+func readIssueMetadata(t *testing.T, storePath string, issue int) map[string]string {
+	t.Helper()
+
+	raw, err := os.ReadFile(storePath)
+	require.NoError(t, err)
+
+	var tasks []map[string]any
+	require.NoError(t, json.Unmarshal(raw, &tasks))
+
+	for _, task := range tasks {
+		meta, ok := task["metadata"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if parseNonNegativeInt(meta[metaKeyIssueNum]) != issue {
+			continue
+		}
+
+		out := make(map[string]string, len(meta))
+		for k, v := range meta {
+			out[k] = parseString(v)
+		}
+		return out
+	}
+
+	t.Fatalf("未找到 issue=%d 的 metadata", issue)
+	return nil
+}
+
+func writeObjectTaskStore(t *testing.T, repoDir string, issue int) string {
+	t.Helper()
+
+	storePath := filepath.Join(repoDir, ".niuma", "tasks.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(storePath), 0o755))
+
+	payload := map[string]any{
+		"version": "1",
+		"tasks": map[string]any{
+			"task-358": map[string]any{
+				"id":      "task-358",
+				"subject": "issue 358",
+				"status":  "in-progress",
+				"metadata": map[string]any{
+					metaKeyIssueNum: strconv.Itoa(issue),
+				},
+			},
+		},
+	}
+	raw, err := json.MarshalIndent(payload, "", "  ")
+	require.NoError(t, err)
+	raw = append(raw, '\n')
+	require.NoError(t, os.WriteFile(storePath, raw, 0o644))
+	return storePath
+}
+
+func readIssueMetadataFromObjectStore(t *testing.T, storePath string, issue int) map[string]string {
+	t.Helper()
+
+	raw, err := os.ReadFile(storePath)
+	require.NoError(t, err)
+
+	var root map[string]any
+	require.NoError(t, json.Unmarshal(raw, &root))
+	tasks, ok := root["tasks"].(map[string]any)
+	require.True(t, ok)
+	for _, item := range tasks {
+		task, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		meta, ok := task["metadata"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if parseNonNegativeInt(meta[metaKeyIssueNum]) != issue {
+			continue
+		}
+		out := make(map[string]string, len(meta))
+		for k, v := range meta {
+			out[k] = parseString(v)
+		}
+		return out
+	}
+	t.Fatalf("未找到 object store issue=%d 的 metadata", issue)
+	return nil
+}


### PR DESCRIPTION
Closes #358

## Summary

## ✅ 最终方案：将 implement/iterate 的 Gate 重试与升级下沉为 `niuma gate run` 统一命令

### 实现方案

1) 在 CLI 层新增 `niuma gate run` 子命令并注册到主命令树，参数为 `--repo`、`--issue`、`--pr`、`--repo-dir`、`--max-retries`（默认 2）。2) 在 `pkg/gate` 实现统一编排器：先执行 `niuma-test-gate.sh`（保持现有 gate 判定语义），失败后读取 `.niuma/tasks.json` 的当前任务状态，递增 `retry_count`，计算 `attempt_key=issue-<issue>-pr-<pr>-<YYYYMMDD>`。3) 分支行为：gate 通过直接返回成功；失败且 `retry_count <= max_retries` 时执行 `niuma state-label set --to bot:pr-needs-fix` 并发评论；失败且超限时打 `needs-human` + `integration-gate-failed` 标签，并在 `last_escalated_attempt_key != attempt_key` 时发布升级评论（去重），随后写回 `last_escalated_attempt_key`。4) `.niuma/tasks.json` 作为去重唯一真源，新增字段采用向后兼容解析（缺省即零值），写入采用原子写（tmp + rename）防止部分写入。5) 改造 `niuma-implement.yml` 与 `niuma-iterate.yml`：删除原 4 个 gate step，替换为 1 个 `niuma gate run` step，保持退出码约定（0 通过，1 失败）。

### 文件变更

| 路径 | 操作 | 描述 |
|------|------|------|
| `automation/niuma/cmd/niuma/main.go` | modify | 注册 `gate` 命令及 `run` 子命令入口，接入统一退出码处理。 |
| `automation/niuma/cmd/niuma/gate_run.go` | add | 定义 `niuma gate run` 参数、校验与调用 `pkg/gate` 服务。 |
| `automation/niuma/pkg/gate/gate.go` | add | 实现 gate 执行、retry 计数、升级分支、attempt_key 去重、tasks.json 原子写。 |
| `automation/niuma/pkg/gate/gate_test.go` | add | 覆盖通过、首次失败、超限升级、重复升级去重、状态持久化等核心路径。 |
| `.github/workflows/niuma-implement.yml` | modify | 用单个 `niuma gate run` step 替换原 4 个 gate 相关 step。 |
| `.github/workflows/niuma-iterate.yml` | modify | 同 implement workflow，合并 gate 逻辑为单命令调用。 |

### 测试场景

1. **Gate 通过**: 输入 ``retry_count=1`，gate 返回 0` → 预期 `命令返回 0；不改标签；不发评论；`retry_count` 不增加。`
2. **首次失败**: 输入 ``retry_count=0`，`max_retries=2`，gate 返回非 0` → 预期 `命令返回 1；`retry_count=1`；设置 `bot:pr-needs-fix`；发送修复评论。`
3. **超限升级**: 输入 ``retry_count=2`，`max_retries=2`，gate 返回非 0` → 预期 `命令返回 1；添加 `needs-human` + `integration-gate-failed`；写入 `last_escalated_attempt_key`；发送升级评论。`
4. **重复升级去重**: 输入 ``retry_count=3`，`last_escalated_attempt_key` 等于当前 attempt_key，gate 返回非 0` → 预期 `命令返回 1；不重复发送升级评论；状态保持幂等。`


---
*方案已定稿，即将开始实现。*
<!-- PLAN_FILES:[{"path":"automation/niuma/cmd/niuma/main.go","action":"modify","description":"注册 `gate` 命令及 `run` 子命令入口，接入统一退出码处理。"},{"path":"automation/niuma/cmd/niuma/gate_run.go","action":"add","description":"定义 `niuma gate run` 参数、校验与调用 `pkg/gate` 服务。"},{"path":"automation/niuma/pkg/gate/gate.go","action":"add","description":"实现 gate 执行、retry 计数、升级分支、attempt_key 去重、tasks.json 原子写。"},{"path":"automation/niuma/pkg/gate/gate_test.go","action":"add","description":"覆盖通过、首次失败、超限升级、重复升级去重、状态持久化等核心路径。"},{"path":".github/workflows/niuma-implement.yml","action":"modify","description":"用单个 `niuma gate run` step 替换原 4 个 gate 相关 step。"},{"path":".github/workflows/niuma-iterate.yml","action":"modify","description":"同 implement workflow，合并 gate 逻辑为单命令调用。"}] -->

Refs #363