### PR TITLE
fix: fix(gate): gate 失败信息未传递给 iterate，导致 codex 盲改 (#377)

### DIFF
--- a/automation/niuma/cmd/niuma/gate_run.go
+++ b/automation/niuma/cmd/niuma/gate_run.go
@@ -85,6 +85,10 @@ func runGateRun(cmd *cobra.Command, args []string) error {
 			_, err := client.AddComment(ctx, issue, body)
 			return err
 		},
+		AddPRReview: func(ctx context.Context, repo string, pr int, body string) error {
+			_, err := client.CreatePRReview(ctx, pr, body, "COMMENT")
+			return err
+		},
 	})
 	if err != nil {
 		return err

--- a/automation/niuma/pkg/gate/gate.go
+++ b/automation/niuma/pkg/gate/gate.go
@@ -38,6 +38,7 @@ type RunGateFunc func(ctx context.Context, repoDir string, pr int) (string, erro
 type MarkNeedsFixFunc func(ctx context.Context, repo string, issue int) error
 type AddLabelsFunc func(ctx context.Context, repo string, issue int, labels []string) error
 type AddCommentFunc func(ctx context.Context, repo string, issue int, body string) error
+type AddPRReviewFunc func(ctx context.Context, repo string, pr int, body string) error
 
 type Options struct {
 	Repo       string
@@ -51,6 +52,7 @@ type Options struct {
 	MarkNeedsFix MarkNeedsFixFunc
 	AddLabels    AddLabelsFunc
 	AddComment   AddCommentFunc
+	AddPRReview  AddPRReviewFunc // 可选：gate 失败时将错误信息写到 PR review，供 iterate 读取
 }
 
 type Runner struct {
@@ -155,6 +157,12 @@ func (r *Runner) Run(ctx context.Context) (Result, error) {
 			commentBody := fmt.Sprintf(defaultNeedsFixCommentTemplate, retryCount, r.opts.MaxRetries, attemptKey)
 			if err := r.opts.AddComment(ctx, r.opts.Repo, r.opts.Issue, commentBody); err != nil {
 				return fmt.Errorf("%w: gate 失败评论发布失败: %v", ErrGateFailed, err)
+			}
+			if r.opts.AddPRReview != nil {
+				reviewBody := formatGateFailureReview(gateFailure)
+				if err := r.opts.AddPRReview(ctx, r.opts.Repo, r.opts.PR, reviewBody); err != nil {
+					fmt.Fprintf(os.Stderr, "WARNING: gate 失败信息写入 PR review 失败: %v\n", err)
+				}
 			}
 			return fmt.Errorf("%w: %s", ErrGateFailed, gateFailure)
 		}
@@ -418,6 +426,10 @@ func parseString(v any) string {
 	default:
 		return strings.TrimSpace(fmt.Sprint(typed))
 	}
+}
+
+func formatGateFailureReview(gateFailure string) string {
+	return fmt.Sprintf("## ❌ Gate 测试失败详情\n\n```\n%s\n```", gateFailure)
 }
 
 func writeAtomicJSON(path string, payload []byte) error {

--- a/automation/niuma/pkg/gate/gate_test.go
+++ b/automation/niuma/pkg/gate/gate_test.go
@@ -377,6 +377,180 @@ func writeObjectTaskStore(t *testing.T, repoDir string, issue int) string {
 	return storePath
 }
 
+func TestRunner_FailurePostsPRReview(t *testing.T) {
+	repoDir := t.TempDir()
+	writeTaskStore(t, repoDir, 358, map[string]string{
+		metaKeyGateRetryCount: "0",
+	})
+
+	prReviewCalled := 0
+	var prReviewBody string
+
+	runner := newRunnerForTest(t, Options{
+		Repo:       "biantaishabi2/Cli",
+		Issue:      358,
+		PR:         9030,
+		RepoDir:    repoDir,
+		MaxRetries: 2,
+		Now:        fixedNow,
+		RunGate: func(context.Context, string, int) (string, error) {
+			return "go test failed: expected \"foo\" got \"bar\"", errors.New("exit status 1")
+		},
+		MarkNeedsFix: func(context.Context, string, int) error { return nil },
+		AddLabels:    func(context.Context, string, int, []string) error { return nil },
+		AddComment:   func(context.Context, string, int, string) error { return nil },
+		AddPRReview: func(_ context.Context, _ string, pr int, body string) error {
+			prReviewCalled++
+			prReviewBody = body
+			assert.Equal(t, 9030, pr)
+			return nil
+		},
+	})
+
+	result, err := runner.Run(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGateFailed)
+	assert.False(t, result.Escalated)
+	assert.Equal(t, 1, prReviewCalled)
+	assert.Contains(t, prReviewBody, "❌ Gate 测试失败详情")
+	assert.Contains(t, prReviewBody, "go test failed")
+	assert.Contains(t, prReviewBody, "exit status 1")
+}
+
+func TestRunner_PassDoesNotPostPRReview(t *testing.T) {
+	repoDir := t.TempDir()
+	writeTaskStore(t, repoDir, 358, map[string]string{})
+
+	prReviewCalled := 0
+
+	runner := newRunnerForTest(t, Options{
+		Repo:       "biantaishabi2/Cli",
+		Issue:      358,
+		PR:         9031,
+		RepoDir:    repoDir,
+		MaxRetries: 2,
+		Now:        fixedNow,
+		RunGate: func(context.Context, string, int) (string, error) {
+			return "ok", nil
+		},
+		MarkNeedsFix: func(context.Context, string, int) error { return nil },
+		AddLabels:    func(context.Context, string, int, []string) error { return nil },
+		AddComment:   func(context.Context, string, int, string) error { return nil },
+		AddPRReview: func(context.Context, string, int, string) error {
+			prReviewCalled++
+			return nil
+		},
+	})
+
+	result, err := runner.Run(context.Background())
+	require.NoError(t, err)
+	assert.True(t, result.Passed)
+	assert.Equal(t, 0, prReviewCalled)
+}
+
+func TestRunner_EscalatedDoesNotPostPRReview(t *testing.T) {
+	repoDir := t.TempDir()
+	writeTaskStore(t, repoDir, 358, map[string]string{
+		metaKeyGateRetryCount: "2",
+	})
+
+	prReviewCalled := 0
+
+	runner := newRunnerForTest(t, Options{
+		Repo:       "biantaishabi2/Cli",
+		Issue:      358,
+		PR:         9032,
+		RepoDir:    repoDir,
+		MaxRetries: 2,
+		Now:        fixedNow,
+		RunGate: func(context.Context, string, int) (string, error) {
+			return "gate failed", errors.New("exit status 1")
+		},
+		MarkNeedsFix: func(context.Context, string, int) error { return nil },
+		AddLabels:    func(context.Context, string, int, []string) error { return nil },
+		AddComment:   func(context.Context, string, int, string) error { return nil },
+		AddPRReview: func(context.Context, string, int, string) error {
+			prReviewCalled++
+			return nil
+		},
+	})
+
+	result, err := runner.Run(context.Background())
+	require.Error(t, err)
+	assert.True(t, result.Escalated)
+	assert.Equal(t, 0, prReviewCalled)
+}
+
+func TestRunner_NilAddPRReviewBackwardCompatible(t *testing.T) {
+	repoDir := t.TempDir()
+	writeTaskStore(t, repoDir, 358, map[string]string{
+		metaKeyGateRetryCount: "0",
+	})
+
+	runner := newRunnerForTest(t, Options{
+		Repo:       "biantaishabi2/Cli",
+		Issue:      358,
+		PR:         9033,
+		RepoDir:    repoDir,
+		MaxRetries: 2,
+		Now:        fixedNow,
+		RunGate: func(context.Context, string, int) (string, error) {
+			return "go test failed", errors.New("exit status 1")
+		},
+		MarkNeedsFix: func(context.Context, string, int) error { return nil },
+		AddLabels:    func(context.Context, string, int, []string) error { return nil },
+		AddComment:   func(context.Context, string, int, string) error { return nil },
+		// AddPRReview 不设置（nil）
+	})
+
+	result, err := runner.Run(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGateFailed)
+	assert.False(t, result.Passed)
+	// 不 panic，不报错
+}
+
+func TestRunner_AddPRReviewFailureDoesNotBlockMainFlow(t *testing.T) {
+	repoDir := t.TempDir()
+	writeTaskStore(t, repoDir, 358, map[string]string{
+		metaKeyGateRetryCount: "0",
+	})
+
+	markCalled := 0
+	commentCalled := 0
+
+	runner := newRunnerForTest(t, Options{
+		Repo:       "biantaishabi2/Cli",
+		Issue:      358,
+		PR:         9034,
+		RepoDir:    repoDir,
+		MaxRetries: 2,
+		Now:        fixedNow,
+		RunGate: func(context.Context, string, int) (string, error) {
+			return "go test failed", errors.New("exit status 1")
+		},
+		MarkNeedsFix: func(context.Context, string, int) error {
+			markCalled++
+			return nil
+		},
+		AddLabels: func(context.Context, string, int, []string) error { return nil },
+		AddComment: func(context.Context, string, int, string) error {
+			commentCalled++
+			return nil
+		},
+		AddPRReview: func(context.Context, string, int, string) error {
+			return errors.New("API timeout")
+		},
+	})
+
+	result, err := runner.Run(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGateFailed)
+	assert.Equal(t, 1, markCalled)
+	assert.Equal(t, 1, commentCalled)
+	assert.False(t, result.Escalated)
+}
+
 func readIssueMetadataFromObjectStore(t *testing.T, storePath string, issue int) map[string]string {
 	t.Helper()
 


### PR DESCRIPTION
Closes #377

## Summary

## ✅ 最终方案：fix(gate): 将测试失败信息作为 PR review 传递给 iterate

### 实现方案

在 gate.Options 中新增可选回调 AddPRReview（签名: func(ctx context.Context, repo string, pr int, body string) error）。gate 失败且处于 retrying 状态时（line 151-158），在发完 issue 评论后额外调用 AddPRReview 将 gateFailure 以 PR review（event=COMMENT）写到 PR 上。iterate 的 DoIterate 已通过 ListPRReviews 读取 PR review，无需改动。AddPRReview 为可选字段（nil 时跳过），不破坏现有调用方和测试。发送失败仅 log warning，不阻断主流程。escalated 时不发（无 iterate 消费者）。

### 文件变更

| 路径 | 操作 | 描述 |
|------|------|------|
| `automation/niuma/pkg/gate/gate.go` | modify | 1) 新增类型 AddPRReviewFunc（与 AddCommentFunc 同签名但语义不同，接受 pr int 而非 issue int）；2) Options 新增可选字段 AddPRReview AddPRReviewFunc；3) NewRunner 中 AddPRReview 为 nil 时不报错（与必选的 AddComment/MarkNeedsFix 区分）；4) Run() 在 line 158（issue 评论成功后、return 前），如果 opts.AddPRReview != nil，调用 AddPRReview(ctx, repo, pr, formatGateFailureComment(gateFailure))，失败仅 fmt.Fprintf(os.Stderr, warning) 不 return error |
| `automation/niuma/pkg/gate/gate_test.go` | modify | 1) 新增 TestRunner_FailurePostsPRReview：gate 失败 + retrying → 验证 AddPRReview 被调用一次，body 包含 gateFailure 内容（'go test failed'），且格式包含 '❌ Gate 测试失败详情'；2) 新增 TestRunner_PassDoesNotPostPRReview：gate 通过 → AddPRReview 不被调用；3) 修改 TestRunner_ExceedRetriesEscalates：追加断言 AddPRReview 调用次数为 0（escalated 时不发）；4) 现有测试不设置 AddPRReview（nil），验证向后兼容不报错 |
| `automation/niuma/cmd/niuma/gate_run.go` | modify | 构造 gate.Options 时注入 AddPRReview 实现：调用 client.CreatePRReview(ctx, pr, body, "COMMENT")，只取 error 返回值 |

### 测试场景

1. **gate 失败 → PR 上可见错误信息**: 输入 `RunGate 返回 ('go test failed: expected "foo" got "bar"', error('exit status 1'))，retryCount=0，maxRetries=2` → 预期 `AddPRReview 被调用，body 包含截断后的测试错误输出 'go test failed: expected "foo" got "bar" | exit status 1'，格式为 markdown code block`
2. **gate 通过时不发 PR review**: 输入 `RunGate 返回 ('ok', nil)` → 预期 `AddPRReview 不被调用，result.Passed=true`
3. **escalated 时不发 PR review**: 输入 `RunGate 失败，retryCount=2（已达 maxRetries=2），下一次 retryCount=3 超限` → 预期 `AddPRReview 不被调用，result.Escalated=true`
4. **AddPRReview 为 nil（向后兼容）**: 输入 `Options 不设置 AddPRReview（nil），RunGate 失败` → 预期 `正常执行，不 panic，不报错，行为与改动前一致`
5. **AddPRReview 发送失败不阻断**: 输入 `AddPRReview 返回 error('API timeout')` → 预期 `Run() 仍返回 ErrGateFailed，MarkNeedsFix 和 AddComment 已执行，stderr 有 warning 日志`


---
*方案已定稿，即将开始实现。*
<!-- PLAN_FILES:[{"path":"automation/niuma/pkg/gate/gate.go","action":"modify","description":"1) 新增类型 AddPRReviewFunc（与 AddCommentFunc 同签名但语义不同，接受 pr int 而非 issue int）；2) Options 新增可选字段 AddPRReview AddPRReviewFunc；3) NewRunner 中 AddPRReview 为 nil 时不报错（与必选的 AddComment/MarkNeedsFix 区分）；4) Run() 在 line 158（issue 评论成功后、return 前），如果 opts.AddPRReview != nil，调用 AddPRReview(ctx, repo, pr, formatGateFailureComment(gateFailure))，失败仅 fmt.Fprintf(os.Stderr, warning) 不 return error"},{"path":"automation/niuma/pkg/gate/gate_test.go","action":"modify","description":"1) 新增 TestRunner_FailurePostsPRReview：gate 失败 + retrying → 验证 AddPRReview 被调用一次，body 包含 gateFailure 内容（'go test failed'），且格式包含 '❌ Gate 测试失败详情'；2) 新增 TestRunner_PassDoesNotPostPRReview：gate 通过 → AddPRReview 不被调用；3) 修改 TestRunner_ExceedRetriesEscalates：追加断言 AddPRReview 调用次数为 0（escalated 时不发）；4) 现有测试不设置 AddPRReview（nil），验证向后兼容不报错"},{"path":"automation/niuma/cmd/niuma/gate_run.go","action":"modify","description":"构造 gate.Options 时注入 AddPRReview 实现：调用 client.CreatePRReview(ctx, pr, body, \"COMMENT\")，只取 error 返回值"}] -->