### PR TITLE
feat(agent): review 判定切换为哨兵键并兼容旧 approved (#395)

### DIFF
--- a/automation/niuma/pkg/agent/parse.go
+++ b/automation/niuma/pkg/agent/parse.go
@@ -10,6 +10,13 @@ import (
 	"strings"
 )
 
+const (
+	// reviewApprovedSentinelKey 是 review 结果的机器判定键（主键）。
+	reviewApprovedSentinelKey = "__niuma_review_approved_v1__"
+	// reviewApprovedLegacyKey 是历史兼容键（兜底读取）。
+	reviewApprovedLegacyKey = "approved"
+)
+
 // RecoverableErrorKind 可恢复错误的分类
 type RecoverableErrorKind string
 
@@ -140,6 +147,7 @@ func ParseReviewResponse(raw string) (*ReviewResult, error) {
 	}
 
 	type reviewJSON struct {
+		ApprovedV1    *bool    `json:"__niuma_review_approved_v1__"`
 		Approved      *bool    `json:"approved"`
 		Summary       string   `json:"summary"`
 		ResolvedItems []string `json:"resolved_items,omitempty"`
@@ -150,8 +158,12 @@ func ParseReviewResponse(raw string) (*ReviewResult, error) {
 	if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
 		return nil, &RecoverableError{Kind: JSONParseError, Err: err, Message: "审查结果 JSON 解析失败"}
 	}
-	if parsed.Approved == nil {
-		return nil, &RecoverableError{Kind: MissingField, Message: "审查结果缺少必填字段 approved"}
+	approved := parsed.ApprovedV1
+	if approved == nil {
+		approved = parsed.Approved
+	}
+	if approved == nil {
+		return nil, &RecoverableError{Kind: MissingField, Message: "审查结果缺少必填字段 __niuma_review_approved_v1__"}
 	}
 	summary := strings.TrimSpace(parsed.Summary)
 	if summary == "" {
@@ -159,7 +171,7 @@ func ParseReviewResponse(raw string) (*ReviewResult, error) {
 	}
 
 	return &ReviewResult{
-		Approved:      *parsed.Approved,
+		Approved:      *approved,
 		Summary:       summary,
 		ResolvedItems: parsed.ResolvedItems,
 		Issues:        parsed.Issues,
@@ -252,7 +264,7 @@ var (
 		{Name: "test_scenarios", Type: "array", Required: false, Desc: "测试场景"},
 	}
 	reviewFields = []FieldSpec{
-		{Name: "approved", Type: "bool", Required: true, Desc: "是否通过审查"},
+		{Name: reviewApprovedSentinelKey, Type: "bool", Required: true, Desc: "是否通过审查（机器判定键，必须输出）"},
 		{Name: "summary", Type: "string", Required: true, Desc: "审查总结"},
 		{Name: "resolved_items", Type: "array", Required: false, Desc: "已解决的问题列表"},
 		{Name: "issues", Type: "array", Required: false, Desc: "新发现的问题列表"},
@@ -309,6 +321,7 @@ func RepairAndParseReview(originalRaw, repairRaw string) (*ReviewResult, error) 
 		return nil, fmt.Errorf("修复回复中未找到 JSON 代码块")
 	}
 	type reviewJSON struct {
+		ApprovedV1    *bool    `json:"__niuma_review_approved_v1__"`
 		Approved      *bool    `json:"approved"`
 		Summary       string   `json:"summary"`
 		ResolvedItems []string `json:"resolved_items,omitempty"`
@@ -318,15 +331,19 @@ func RepairAndParseReview(originalRaw, repairRaw string) (*ReviewResult, error) 
 	if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
 		return nil, fmt.Errorf("修复回复 JSON 解析失败: %w", err)
 	}
-	if parsed.Approved == nil {
-		return nil, fmt.Errorf("修复回复缺少 approved 字段")
+	approved := parsed.ApprovedV1
+	if approved == nil {
+		approved = parsed.Approved
+	}
+	if approved == nil {
+		return nil, fmt.Errorf("修复回复缺少 %s 字段", reviewApprovedSentinelKey)
 	}
 	summary := strings.TrimSpace(parsed.Summary)
 	if summary == "" {
 		return nil, fmt.Errorf("修复回复缺少 summary 字段")
 	}
 	return &ReviewResult{
-		Approved:      *parsed.Approved,
+		Approved:      *approved,
 		Summary:       summary,
 		ResolvedItems: parsed.ResolvedItems,
 		Issues:        parsed.Issues,

--- a/automation/niuma/pkg/agent/parse_test.go
+++ b/automation/niuma/pkg/agent/parse_test.go
@@ -148,6 +148,16 @@ func TestParseReviewResponse_Approved(t *testing.T) {
 	assert.Empty(t, result.Issues)
 }
 
+func TestParseReviewResponse_ApprovedWithSentinelKey(t *testing.T) {
+	raw := `{"__niuma_review_approved_v1__": true, "summary": "代码质量良好，符合方案要求", "issues": []}`
+
+	result, err := ParseReviewResponse(raw)
+	require.NoError(t, err)
+	assert.True(t, result.Approved)
+	assert.Equal(t, "代码质量良好，符合方案要求", result.Summary)
+	assert.Empty(t, result.Issues)
+}
+
 func TestParseReviewResponse_NotApproved(t *testing.T) {
 	raw := `{"approved": false, "summary": "发现若干问题", "issues": ["缺少错误处理", "变量命名不规范"]}`
 
@@ -402,6 +412,14 @@ func TestRepairAndParseFinalPlan_NoJSON(t *testing.T) {
 
 func TestRepairAndParseReview_Success(t *testing.T) {
 	repairRaw := `{"approved":true,"summary":"代码质量良好"}`
+	result, err := RepairAndParseReview("原始文本", repairRaw)
+	require.NoError(t, err)
+	assert.True(t, result.Approved)
+	assert.Equal(t, "代码质量良好", result.Summary)
+}
+
+func TestRepairAndParseReview_SuccessWithSentinelKey(t *testing.T) {
+	repairRaw := `{"__niuma_review_approved_v1__":true,"summary":"代码质量良好"}`
 	result, err := RepairAndParseReview("原始文本", repairRaw)
 	require.NoError(t, err)
 	assert.True(t, result.Approved)

--- a/automation/niuma/pkg/agent/prompt.go
+++ b/automation/niuma/pkg/agent/prompt.go
@@ -368,9 +368,9 @@ const reviewTmpl = `你是一个务实的代码审查员。请审查以下 PR �
 - 确认问题确实存在（不要猜测 build tag 或 API 行为）
 - 如果涉及外部系统行为（如 GitHub API），标明"需确认"
 
-**approved 判定规则（必须严格遵守）：**
-**- 存在任何 P0 或 P1 问题 → 必须设 approved=false**
-**- 只有 P2 问题或无问题 → 设 approved=true**
+**判定字段规则（必须严格遵守）：**
+**- 存在任何 P0 或 P1 问题 → 必须设 ` + "`__niuma_review_approved_v1__=false`" + `**
+**- 只有 P2 问题或无问题 → 设 ` + "`__niuma_review_approved_v1__=true`" + `**
 
 {{- if .ReviewComment}}
 
@@ -380,16 +380,16 @@ PR 历史中包含之前的 review 和回复。你必须：
 1. 逐条检查之前提出的每个问题，确认是否已修复
 2. 对于 implementer 反驳的问题（认为不是 bug），明确表态你是否接受其解释
 3. **resolved_items 是必填字段，不能为空数组**——必须逐条列出每个历史问题的结论
-4. 当 resolved_items 中有"仍需修改"的条目 → 也必须设 approved=false
+4. 当 resolved_items 中有"仍需修改"的条目 → 也必须设 ` + "`__niuma_review_approved_v1__=false`" + `
 {{- end}}
 
 **最终输出格式（必须严格遵守）：**
 
 在你的回复最末尾，必须输出一个 ` + "```json```" + ` 代码块，不要在 JSON 后面再写任何文字。
-如果无法给出明确结论，必须返回 ` + "`approved=false`" + `，禁止用自然语言替代 JSON：
+如果无法给出明确结论，必须返回 ` + "`__niuma_review_approved_v1__=false`" + `，禁止用自然语言替代 JSON：
 ` + "```json" + `
 {
-  "approved": true或false,
+  "__niuma_review_approved_v1__": true或false,
   "summary": "一句话审查总结",
   "resolved_items": ["之前的问题X：已修复/接受解释/仍需修改"],
   "issues": ["P0/P1/P2 - 具体问题描述（仅新发现的问题）"]


### PR DESCRIPTION
Closes #395

## Summary
- review 结果解析新增机器判定键 `__niuma_review_approved_v1__`（主键）。
- 保留旧键 `approved` 兼容兜底，避免现网抖动。
- review prompt 输出模板切换为新键，减少正文歧义干扰。
- 补充解析测试：新键正常解析与 repair 解析路径。

## Test plan
- go test ./pkg/agent -count=1
- go test ./... -count=1  (in automation/niuma)
