### PR TITLE
fix: feat: bcc extract Elixir 提取器补充 RelationHint 输出 (#394)

### DIFF
--- a/compiler/bcc/src/arch/injection.rs
+++ b/compiler/bcc/src/arch/injection.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 /// 注入提示最小置信度，低于阈值统一降级为 direct_call。
 pub const MIN_HINT_CONFIDENCE: f64 = 0.75;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CallType {
     DirectCall,

--- a/compiler/bcc/src/extract/elixir.rs
+++ b/compiler/bcc/src/extract/elixir.rs
@@ -1,5 +1,6 @@
 use super::common;
 use super::*;
+use crate::arch::injection::CallType;
 use regex::Regex;
 use std::collections::HashMap;
 
@@ -396,7 +397,7 @@ fn detect_relation_hints(imports: &[ImportRecord], content: &str) -> Vec<Relatio
         for target in extract_use_injected_modules(&imp.specifier) {
             hints.push(RelationHintRecord {
                 target,
-                call_type_hint: "framework_injection".to_string(),
+                call_type_hint: CallType::FrameworkInjection,
                 via: via.clone(),
                 confidence: 0.92,
                 detector: "elixir.use_macro".to_string(),
@@ -414,13 +415,19 @@ fn detect_relation_hints(imports: &[ImportRecord], content: &str) -> Vec<Relatio
         }
         hints.push(RelationHintRecord {
             target: target_module,
-            call_type_hint: "external_registration".to_string(),
+            call_type_hint: CallType::ExternalRegistration,
             via: format!("{}.register", lib_chain),
             confidence: 0.97,
             detector: "elixir.external_register".to_string(),
             reason: "外部库 register 调用内部模块".to_string(),
         });
     }
+
+    // supervisor children = [...] 中的模块引用
+    hints.extend(detect_supervisor_children(content));
+
+    // Keyword.get/fetch!/opts[:key] 配置注入
+    hints.extend(detect_opts_injection(content));
 
     hints.sort_by(|a, b| {
         a.target
@@ -434,6 +441,188 @@ fn detect_relation_hints(imports: &[ImportRecord], content: &str) -> Vec<Relatio
             && a.via == b.via
             && a.detector == b.detector
     });
+    hints
+}
+
+/// OTP 标准库模块，supervisor children 中出现时不产出 hint
+const OTP_STDLIB_MODULES: &[&str] = &[
+    "Registry",
+    "DynamicSupervisor",
+    "Task.Supervisor",
+    "Supervisor",
+    "Agent",
+    "GenServer",
+    "Task",
+    "Telemetry",
+    "Phoenix.PubSub",
+];
+
+/// 检测 supervisor children = [...] 中的模块引用
+/// 识别 {Module, opts} 元组和裸 Module 两种形式
+fn detect_supervisor_children(content: &str) -> Vec<RelationHintRecord> {
+    let mut hints = Vec::new();
+    // 匹配 children = [...] 赋值（包括跨行）
+    let children_re = Regex::new(r"(?s)children\s*=\s*\[([^\]]*)\]").expect("valid children regex");
+
+    for cap in children_re.captures_iter(content) {
+        let Some(body) = cap.get(1).map(|m| m.as_str()) else {
+            continue;
+        };
+        if body.trim().is_empty() {
+            continue;
+        }
+
+        // 匹配 {Module.Name, ...} 元组形式
+        let tuple_re =
+            Regex::new(r"\{\s*([A-Z][A-Za-z0-9_.]+)").expect("valid tuple module regex");
+        for tuple_cap in tuple_re.captures_iter(body) {
+            let Some(module) = tuple_cap.get(1).map(|m| m.as_str()) else {
+                continue;
+            };
+            if !is_otp_stdlib(module) {
+                hints.push(RelationHintRecord {
+                    target: module.to_string(),
+                    call_type_hint: CallType::FrameworkInjection,
+                    via: "children supervisor spec".to_string(),
+                    confidence: 0.90,
+                    detector: "elixir.supervisor".to_string(),
+                    reason: "Supervisor child spec 中的模块引用".to_string(),
+                });
+            }
+        }
+
+        // 匹配裸模块引用（不在 {} 内的独立模块名）
+        // 先去掉已匹配的 {Module, ...} 部分，再扫描剩余的裸模块名
+        let cleaned = tuple_re.replace_all(body, " ");
+        let bare_re =
+            Regex::new(r"(?:^|[,\s])([A-Z][A-Za-z0-9]*(?:\.[A-Z][A-Za-z0-9_]*)*)(?:[,\s\]]|$)")
+                .expect("valid bare module regex");
+        for bare_cap in bare_re.captures_iter(&cleaned) {
+            let Some(module) = bare_cap.get(1).map(|m| m.as_str()) else {
+                continue;
+            };
+            // 裸模块至少两段才有意义（单段如 Registry 是 OTP）
+            if module.contains('.') && !is_otp_stdlib(module) {
+                hints.push(RelationHintRecord {
+                    target: module.to_string(),
+                    call_type_hint: CallType::FrameworkInjection,
+                    via: "children supervisor spec".to_string(),
+                    confidence: 0.90,
+                    detector: "elixir.supervisor".to_string(),
+                    reason: "Supervisor child spec 中的模块引用".to_string(),
+                });
+            }
+        }
+    }
+
+    hints
+}
+
+fn is_otp_stdlib(module: &str) -> bool {
+    OTP_STDLIB_MODULES.iter().any(|&m| m == module)
+}
+
+/// 检测 Keyword.get/fetch!/opts[:key] 配置注入模式
+/// 高置信度：同函数体内 Keyword.get 返回值被用于 Module.function() 调用
+/// 低置信度：仅标记存在 opts 注入点
+fn detect_opts_injection(content: &str) -> Vec<RelationHintRecord> {
+    let mut hints = Vec::new();
+    // 匹配函数体（def ... do ... end 块）
+    let func_re = Regex::new(
+        r"(?s)def\s+\w+\s*\([^)]*opts[^)]*\)\s+do\s+(.*?)(?:\n\s*end\b)",
+    )
+    .expect("valid func regex");
+
+    // 匹配 Keyword.get(opts, :key) / Keyword.fetch!(opts, :key)
+    let keyword_re = Regex::new(
+        r"(\w+)\s*=\s*Keyword\.(?:get|fetch!)\s*\(\s*opts\s*,\s*:(\w+)",
+    )
+    .expect("valid keyword regex");
+
+    // 匹配 opts[:key] 形式
+    let opts_bracket_re =
+        Regex::new(r"(\w+)\s*=\s*opts\s*\[\s*:(\w+)\s*\]").expect("valid opts bracket regex");
+
+    // 匹配 Module.function(...) 调用（大写开头模块）
+    let module_call_re = Regex::new(r"([A-Z][A-Za-z0-9]*(?:\.[A-Z][A-Za-z0-9_]*)*)\.\w+\(")
+        .expect("valid module call regex");
+
+    for func_cap in func_re.captures_iter(content) {
+        let Some(body) = func_cap.get(1).map(|m| m.as_str()) else {
+            continue;
+        };
+
+        // 收集该函数体内所有 opts 注入的变量名
+        let mut injected_vars: Vec<(String, String)> = Vec::new(); // (var_name, via_text)
+        for kw_cap in keyword_re.captures_iter(body) {
+            let var = kw_cap.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
+            let key = kw_cap.get(2).map(|m| m.as_str()).unwrap_or_default();
+            let via = format!("Keyword.get(opts, :{})", key);
+            injected_vars.push((var, via));
+        }
+        for ob_cap in opts_bracket_re.captures_iter(body) {
+            let var = ob_cap.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
+            let key = ob_cap.get(2).map(|m| m.as_str()).unwrap_or_default();
+            let via = format!("opts[:{}]", key);
+            injected_vars.push((var, via));
+        }
+
+        if injected_vars.is_empty() {
+            continue;
+        }
+
+        // 收集函数体内的模块调用
+        let module_calls: Vec<String> = module_call_re
+            .captures_iter(body)
+            .filter_map(|c| c.get(1).map(|m| m.as_str().to_string()))
+            .collect();
+
+        for (var, via) in &injected_vars {
+            // 高置信度：变量被用作模块调用的参数，或同体内有相关模块调用
+            let mut matched_module = false;
+            for module in &module_calls {
+                // 检查变量是否出现在该模块调用附近（简单启发式：同函数体内有 module 调用且变量被使用）
+                let call_pattern = format!("{}.", module);
+                if body.contains(&call_pattern) && body.contains(var.as_str()) {
+                    // 检查变量是否出现在模块调用参数中
+                    let usage_re = Regex::new(&format!(
+                        r"{}\.\w+\([^)]*{}[^)]*\)",
+                        regex::escape(module),
+                        regex::escape(var)
+                    ));
+                    if let Ok(re) = usage_re {
+                        if re.is_match(body) {
+                            hints.push(RelationHintRecord {
+                                target: module.clone(),
+                                call_type_hint: CallType::FrameworkInjection,
+                                via: via.clone(),
+                                confidence: 0.80,
+                                detector: "elixir.opts_injection".to_string(),
+                                reason: format!(
+                                    "opts 注入变量 {} 被传入 {} 模块调用",
+                                    var, module
+                                ),
+                            });
+                            matched_module = true;
+                        }
+                    }
+                }
+            }
+
+            if !matched_module {
+                // 低置信度：仅标记存在注入点
+                hints.push(RelationHintRecord {
+                    target: "unknown".to_string(),
+                    call_type_hint: CallType::FrameworkInjection,
+                    via: via.clone(),
+                    confidence: 0.50,
+                    detector: "elixir.opts_injection".to_string(),
+                    reason: format!("opts 注入变量 {} 无法追踪目标模块", var),
+                });
+            }
+        }
+    }
+
     hints
 }
 
@@ -921,7 +1110,7 @@ end
         assert!(record
             .relation_hints
             .iter()
-            .all(|h| h.call_type_hint == "framework_injection"));
+            .all(|h| h.call_type_hint == CallType::FrameworkInjection));
     }
 
     #[test]
@@ -939,7 +1128,7 @@ end
             .iter()
             .find(|h| h.target == "Gong.Provider.Anthropic")
             .expect("external register hint should exist");
-        assert_eq!(hit.call_type_hint, "external_registration");
+        assert_eq!(hit.call_type_hint, CallType::ExternalRegistration);
         assert!(hit.via.contains("ReqLLM.Providers.register"));
     }
 
@@ -956,7 +1145,7 @@ end
         assert!(record
             .relation_hints
             .iter()
-            .all(|h| h.call_type_hint != "external_registration"));
+            .all(|h| h.call_type_hint != CallType::ExternalRegistration));
     }
 
     #[test]
@@ -972,7 +1161,7 @@ end
         assert!(record
             .relation_hints
             .iter()
-            .all(|h| h.call_type_hint != "external_registration"));
+            .all(|h| h.call_type_hint != CallType::ExternalRegistration));
     }
 }
 

--- a/compiler/bcc/src/extract/mod.rs
+++ b/compiler/bcc/src/extract/mod.rs
@@ -1,3 +1,4 @@
+use crate::arch::injection::CallType;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
 use std::fs;
@@ -54,7 +55,7 @@ pub struct CallRecord {
 pub struct RelationHintRecord {
     pub target: String,
     #[serde(default)]
-    pub call_type_hint: String,
+    pub call_type_hint: CallType,
     #[serde(default)]
     pub via: String,
     #[serde(default)]

--- a/compiler/bcc/src/extract/typescript.rs
+++ b/compiler/bcc/src/extract/typescript.rs
@@ -1,5 +1,6 @@
 use super::common;
 use super::*;
+use crate::arch::injection::CallType;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -624,7 +625,7 @@ fn detect_relation_hints(
                 };
                 hints.push(RelationHintRecord {
                     target: specifier,
-                    call_type_hint: "framework_injection".to_string(),
+                    call_type_hint: CallType::FrameworkInjection,
                     via: format!("@Module.{}", field),
                     confidence,
                     detector: "typescript.nest.module".to_string(),
@@ -664,7 +665,7 @@ fn detect_relation_hints(
             };
             hints.push(RelationHintRecord {
                 target: specifier,
-                call_type_hint: "framework_injection".to_string(),
+                call_type_hint: CallType::FrameworkInjection,
                 via: format!("@{} constructor", decorator),
                 confidence: 0.86,
                 detector: "typescript.nest.constructor".to_string(),
@@ -878,7 +879,7 @@ export class AppModule {}
         assert!(record
             .relation_hints
             .iter()
-            .all(|h| h.call_type_hint == "framework_injection"));
+            .all(|h| h.call_type_hint == CallType::FrameworkInjection));
     }
 
     #[test]
@@ -895,7 +896,7 @@ export class AppService {
         let record = extract(source, "apps/api/src/app.service.ts", "typescript");
         assert!(record.relation_hints.iter().any(|h| {
             h.target == "@app/user"
-                && h.call_type_hint == "framework_injection"
+                && h.call_type_hint == CallType::FrameworkInjection
                 && h.via.contains("@Injectable")
         }));
     }

--- a/compiler/bcc/tests/injection_detector_unit.rs
+++ b/compiler/bcc/tests/injection_detector_unit.rs
@@ -122,10 +122,10 @@ end
     assert!(record
         .relation_hints
         .iter()
-        .any(|h| h.target == "Gong.Tools.Read" && h.call_type_hint == "framework_injection"));
+        .any(|h| h.target == "Gong.Tools.Read" && h.call_type_hint == CallType::FrameworkInjection));
     assert!(record.relation_hints.iter().any(|h| {
         h.target == "Gong.Provider.Anthropic"
-            && h.call_type_hint == "external_registration"
+            && h.call_type_hint == CallType::ExternalRegistration
             && h.via.contains("ReqLLM.Providers.register")
     }));
 }
@@ -144,7 +144,7 @@ end
     assert!(record
         .relation_hints
         .iter()
-        .all(|h| h.call_type_hint != "external_registration"));
+        .all(|h| h.call_type_hint != CallType::ExternalRegistration));
 }
 
 #[test]
@@ -163,7 +163,7 @@ end
     assert!(record
         .relation_hints
         .iter()
-        .all(|h| h.call_type_hint != "external_registration"));
+        .all(|h| h.call_type_hint != CallType::ExternalRegistration));
 }
 
 #[test]


### PR DESCRIPTION
Closes #394

## Summary

## ✅ 最终方案：bcc extract Elixir 提取器补充 supervisor 和 opts_injection 检测器 + call_type_hint 类型统一

### 实现方案

增量扩展现有 Elixir 关系提示检测器体系。当前已有 elixir.use_macro（confidence 0.92）和 elixir.external_register（confidence 0.97）两个检测器，本次新增两个检测器并统一类型系统：

**变更 1：call_type_hint 类型统一（String → CallType enum）**
将 extract/mod.rs 中 RelationHintRecord.call_type_hint 从 String 改为 arch::injection::CallType enum。由于 CallType 已有 #[serde(rename_all = "snake_case")] 和 Serialize/Deserialize，JSON 序列化格式完全兼容（输出仍为 "framework_injection" 等字符串）。需要：
- 为 CallType 补充 derive PartialOrd, Ord（用于排序比较）
- 更新 elixir.rs 和 typescript.rs 中所有 RelationHintRecord 构造处
- 更新 extract/mod.rs 中 resolve_relation_hints 的排序比较
- 更新 injection_detector_unit.rs 中的字符串比较为 enum 比较

**变更 2：elixir.supervisor 检测器**
在 extract/elixir.rs 中新增 detect_supervisor_children() 函数：
- 用 tree-sitter AST 遍历，匹配 children = [...] 赋值中的列表
- 识别两种形式：裸模块 Module（如 Registry）和元组 {Module, opts}（如 {DynamicSupervisor, name: ...}）
- 排除 OTP 标准库模块（Registry, DynamicSupervisor, Task.Supervisor 等），只输出项目内部模块
- confidence: 0.90，call_type_hint: FrameworkInjection，detector: "elixir.supervisor"

**变更 3：elixir.opts_injection 检测器**
在 extract/elixir.rs 中新增 detect_opts_injection() 函数，采用分层置信度策略：
- 用正则匹配 Keyword.get(opts, :key) / Keyword.fetch!(opts, :key) / opts[:key] 模式
- 高置信度路径（0.75-0.85）：当同函数体内 Keyword.get 的返回值被用于 Module.function() 调用时，target 设为该 Module
- 低置信度路径（0.50）：仅标记存在 opts 注入点，target 设为 "unknown"
- call_type_hint: FrameworkInjection，detector: "elixir.opts_injection"

**不纳入本次：** 回调函数参数注入（拆为单独 Issue）、扩展钩子/trait（YAGNI）

### 文件变更

| 路径 | 操作 | 描述 |
|------|------|------|
| `compiler/bcc/src/arch/injection.rs` | modify | 为 CallType enum 补充 derive PartialOrd, Ord，使其可在 Vec<RelationHintRecord> 排序中使用 |
| `compiler/bcc/src/extract/mod.rs` | modify | 1) 添加 use crate::arch::injection::CallType; 2) 将 RelationHintRecord.call_type_hint 类型从 String 改为 CallType; 3) 更新 resolve_relation_hints() 中的排序比较（原 String cmp 改为 CallType cmp） |
| `compiler/bcc/src/extract/elixir.rs` | modify | 1) 将现有 use_macro 和 external_register 检测器中 call_type_hint 字符串字面量改为 CallType enum 变体; 2) 新增 detect_supervisor_children() 函数——解析 children = [...] 中的 {Module, opts} 和裸 Module 形式; 3) 新增 detect_opts_injection() 函数——匹配 Keyword.get/fetch!/opts[:key] 模式，分层置信度策略; 4) 在 detect_relation_hints() 中调用新增的两个检测器 |
| `compiler/bcc/src/extract/typescript.rs` | modify | 将 RelationHintRecord 构造中的 call_type_hint 字符串字面量改为 CallType::FrameworkInjection（两处） |
| `compiler/bcc/tests/injection_detector_unit.rs` | modify | 将 h.call_type_hint == "framework_injection" 等字符串比较改为 h.call_type_hint == CallType::FrameworkInjection 等 enum 比较 |

### 测试场景

1. **Gong application.ex supervisor 检测**: 输入 `children = [
  {Registry, keys: :unique, name: Gong.SessionRegistry},
  {DynamicSupervisor, name: Gong.SessionSupervisor},
  {Gong.SessionManager, []}
]` → 预期 `1 条 hint: target=Gong.SessionManager, detector=elixir.supervisor, confidence=0.90, call_type_hint=framework_injection`
2. **opts 注入 + 同函数体模块调用（高置信度）**: 输入 `def start_link(opts) do
  tape_store = Keyword.get(opts, :tape_store)
  TapeStore.init(tape_store)
end` → 预期 `1 条 hint: target=TapeStore（解析为文件路径）, confidence=0.80, detector=elixir.opts_injection`
3. **opts 注入无后续调用（低置信度）**: 输入 `def start_link(opts) do
  backend = Keyword.get(opts, :llm_backend)
  GenServer.start_link(__MODULE__, %{backend: backend})
end` → 预期 `1 条 hint: target=unknown, confidence=0.50, detector=elixir.opts_injection`
4. **Keyword.fetch! 变体**: 输入 `compaction = Keyword.fetch!(opts, :compaction)` → 预期 `被检测到，与 Keyword.get 同等处理`
5. **空 children 列表**: 输入 `children = []` → 预期 `无 hint 输出`
6. **类型统一后 JSON 反序列化兼容**: 输入 `{"call_type_hint": "framework_injection", "target": "foo", ...}` → 预期 `反序列化为 RelationHintRecord { call_type_hint: CallType::FrameworkInjection, ... } 无报错`


---
*方案已定稿，即将开始实现。*
<!-- PLAN_FILES:[{"path":"compiler/bcc/src/arch/injection.rs","action":"modify","description":"为 CallType enum 补充 derive PartialOrd, Ord，使其可在 Vec\u003cRelationHintRecord\u003e 排序中使用"},{"path":"compiler/bcc/src/extract/mod.rs","action":"modify","description":"1) 添加 use crate::arch::injection::CallType; 2) 将 RelationHintRecord.call_type_hint 类型从 String 改为 CallType; 3) 更新 resolve_relation_hints() 中的排序比较（原 String cmp 改为 CallType cmp）"},{"path":"compiler/bcc/src/extract/elixir.rs","action":"modify","description":"1) 将现有 use_macro 和 external_register 检测器中 call_type_hint 字符串字面量改为 CallType enum 变体; 2) 新增 detect_supervisor_children() 函数——解析 children = [...] 中的 {Module, opts} 和裸 Module 形式; 3) 新增 detect_opts_injection() 函数——匹配 Keyword.get/fetch!/opts[:key] 模式，分层置信度策略; 4) 在 detect_relation_hints() 中调用新增的两个检测器"},{"path":"compiler/bcc/src/extract/typescript.rs","action":"modify","description":"将 RelationHintRecord 构造中的 call_type_hint 字符串字面量改为 CallType::FrameworkInjection（两处）"},{"path":"compiler/bcc/tests/injection_detector_unit.rs","action":"modify","description":"将 h.call_type_hint == \"framework_injection\" 等字符串比较改为 h.call_type_hint == CallType::FrameworkInjection 等 enum 比较"}] -->