### PR TITLE
fix: fix(control): integration merge 冲突直接 escalate 无 retry + needs-human 死胡同 (#410)

### DIFF
--- a/automation/niuma/pkg/control/controller.go
+++ b/automation/niuma/pkg/control/controller.go
@@ -2682,8 +2682,9 @@ func (c *Controller) tryResolveIntegrationConflictWithAI(ctx context.Context, ta
 		return false
 	}
 
-	// AI 解冲突成功，git add 并 commit
-	if _, err := c.runCommand(ctx, repoDir, "git", "add", "."); err != nil {
+	// AI 解冲突成功，只 git add 冲突文件（避免将无关变更带入 merge commit）
+	gitAddArgs := append([]string{"add", "--"}, conflictFiles...)
+	if _, err := c.runCommand(ctx, repoDir, "git", gitAddArgs...); err != nil {
 		fmt.Printf("[control] AI 解冲突后 git add 失败: %v\n", err)
 		c.runCommand(ctx, repoDir, "git", "merge", "--abort")
 		return false
@@ -2725,9 +2726,11 @@ func (c *Controller) handleIntegrationConflictRetry(ctx context.Context, task Ta
 		return
 	}
 
-	// 更新 retry marker
+	// 更新 retry marker（失败则 escalate，避免 retryCount 无法递增导致无限重试）
 	if err := c.persistIntegrationConflictRetryCount(ctx, issue, retryCount); err != nil {
-		fmt.Printf("[control] 写入 integration retry marker 失败 (issue #%d): %v\n", issueNum, err)
+		fmt.Printf("[control] 写入 integration retry marker 失败 (issue #%d)，escalate: %v\n", issueNum, err)
+		c.escalateIntegrationConflict(ctx, task, outcome)
+		return
 	}
 
 	// 写 comment 标注来源
@@ -2860,7 +2863,7 @@ func (c *Controller) reconcileNeedsHumanRecovery(ctx context.Context, tasks []Ta
 			}
 		}
 
-		// 只有标签清理成功才清除 metadata，否则保留以便下次 reconcile 重试
+		// 只有标签清理成功才清除 metadata 和写恢复 comment，否则保留以便下次 reconcile 重试
 		if labelsCleaned {
 			clearMeta := map[string]string{
 				metaKeyIntegrationConflictLabelSynced: "",
@@ -2869,16 +2872,15 @@ func (c *Controller) reconcileNeedsHumanRecovery(ctx context.Context, tasks []Ta
 			if err := c.taskctl.Update(task.ID, UpdateOpts{Metadata: &clearMeta}); err != nil {
 				fmt.Printf("[control] 清除 task %s 的 escalation metadata 失败: %v\n", task.ID, err)
 			}
-		}
 
-		// 写恢复日志 comment
-		recoveryComment := fmt.Sprintf(
-			"<!-- BOT:NEEDS_HUMAN_RECOVERY -->\n\n"+
-				"**自动恢复**: issue #%d PR 已恢复 MERGEABLE 状态，从 `needs-human` + `integration-conflict` 恢复到 `bot:pr-reviewable`。",
-			issueNum,
-		)
-		if err := c.github.AddIssueComment(ctx, issueNum, recoveryComment); err != nil {
-			fmt.Printf("[control] issue #%d 写恢复 comment 失败: %v\n", issueNum, err)
+			recoveryComment := fmt.Sprintf(
+				"<!-- BOT:NEEDS_HUMAN_RECOVERY -->\n\n"+
+					"**自动恢复**: issue #%d PR 已恢复 MERGEABLE 状态，从 `needs-human` + `integration-conflict` 恢复到 `bot:pr-reviewable`。",
+				issueNum,
+			)
+			if err := c.github.AddIssueComment(ctx, issueNum, recoveryComment); err != nil {
+				fmt.Printf("[control] issue #%d 写恢复 comment 失败: %v\n", issueNum, err)
+			}
 		}
 	}
 }

--- a/automation/niuma/pkg/control/controller_test.go
+++ b/automation/niuma/pkg/control/controller_test.go
@@ -43,6 +43,7 @@ type mockGitHubOps struct {
 	addLabelError             map[string]error
 	addLabelFails             map[string]int
 	updateIssueBodyCalls      []updateIssueBodyCall
+	updateIssueBodyError      map[int]error
 	listCommentBodies         map[int][]string
 	addIssueCommentCalls      []addIssueCommentCall
 	closeIssueCalls           []int
@@ -151,6 +152,11 @@ func (m *mockGitHubOps) UpdateIssueBody(_ context.Context, issueNumber int, body
 		issueNumber: issueNumber,
 		body:        body,
 	})
+	if m.updateIssueBodyError != nil {
+		if err, ok := m.updateIssueBodyError[issueNumber]; ok {
+			return err
+		}
+	}
 	issue, ok := m.issuesByNumber[issueNumber]
 	if ok {
 		issue.Body = body
@@ -4117,6 +4123,9 @@ func TestReconcileNeedsHumanRecovery_LabelCleanupFailRetainsMetadata(t *testing.
 		assert.NotContains(t, logText, metaKeyIntegrationConflictLabelSynced,
 			"标签清理失败时不应清除 escalation metadata")
 	}
+
+	// 标签清理失败时，不应写恢复 comment（避免评论与真实标签状态不一致）
+	assert.Empty(t, mockGH.addIssueCommentCalls, "标签清理失败时不应写恢复 comment")
 }
 
 func TestHandleIntegrationConflictRetry_FirstRetry(t *testing.T) {
@@ -4155,4 +4164,51 @@ func TestHandleIntegrationConflictRetry_FirstRetry(t *testing.T) {
 	// should write comment with retry 1/3
 	require.Len(t, mockGH.addIssueCommentCalls, 1)
 	assert.Contains(t, mockGH.addIssueCommentCalls[0].body, "retry 1/3")
+}
+
+func TestHandleIntegrationConflictRetry_MarkerWriteFailEscalates(t *testing.T) {
+	// 验证 retry marker 写入失败时直接 escalate，避免 retryCount 无法递增导致无限重试
+	mockGH := newMockGitHubOps(
+		IssueInfo{
+			Number: 45,
+			Body:   "issue body without marker",
+			Labels: []string{"bot:pr-reviewable"},
+		},
+	)
+	mockGH.updateIssueBodyError = map[int]error{
+		45: fmt.Errorf("simulated UpdateIssueBody failure"),
+	}
+
+	ctrl := &Controller{
+		github: mockGH,
+		taskctl: &TaskCtlClient{
+			BinPath:   "/bin/true",
+			StorePath: t.TempDir() + "/tasks.json",
+		},
+		cfg: DefaultControlConfig(),
+	}
+
+	task := Task{
+		ID:       "task-45",
+		Metadata: map[string]string{"issue_num": "45"},
+	}
+	outcome := MergeOutcome{
+		Status:            MergeStatusEscalated,
+		SourceBranch:      "feat/45-feature",
+		IntegrationBranch: "integration/main",
+	}
+
+	ctrl.handleIntegrationConflictRetry(context.Background(), task, outcome)
+
+	// retry marker 写入失败，不应回退到 bot:pr-needs-fix（应走 escalate）
+	for _, call := range mockGH.replaceLabelCalls {
+		assert.NotEqual(t, "bot:pr-needs-fix", call.newLabel,
+			"retry marker 写入失败时不应回退到 bot:pr-needs-fix")
+	}
+
+	// 不应写 retry comment（因为直接 escalate 了）
+	for _, call := range mockGH.addIssueCommentCalls {
+		assert.NotContains(t, call.body, "retry 1/3",
+			"retry marker 写入失败时不应写 retry comment")
+	}
 }


### PR DESCRIPTION
Closes #410

## Summary

## ✅ 最终方案：Integration merge 冲突 AI 解冲突 + retry + needs-human 自动恢复

### 实现方案

两步修复，均在 controller.go 中完成，不修改 integration.go 的 IntegrationBuilder（它不持有 Controller 引用）。

**Step 1: 拦截 MergeStatusEscalated，插入 AI 解冲突 + retry**

在 controller.go ~line 948 的 `case MergeStatusEscalated:` 分支中，escalate 前先调用新方法 `tryResolveIntegrationConflictWithAI(ctx, task, outcome)`：

1. 从 `c.builder.repoDir` 获取工作目录（同包可访问未导出字段）
2. 从 `outcome.SourceBranch` 获取 PR 分支名
3. 在 `repoDir` 中重新执行 `git merge --no-commit <pr-branch>` 重现冲突（因为 abortAndEscalate 已执行 git merge --abort，冲突状态已丢失）
4. 收集冲突详情：`collectPRConflictDetails(ctx, repoDir)`
5. 检查 AI 白名单：`allowAIConflictResolution(conflictFiles, summaries)`
6. 通过白名单 → 调用 `tryResolveConflictByAIOnce(ctx, repoDir, ...)` 尝试 AI 解冲突
7. AI 成功 → `git add . && git commit --no-edit` 完成 merge commit → 返回 true，controller 继续走 integration gate
8. AI 失败 → `git merge --abort` 恢复干净状态 → 走 retry 机制

Retry 机制：
- 新增 `integrationConflictRetryMarkerRe`（`<!-- INTEGRATION_CONFLICT_RETRY:N -->`），写入 issue body
- `parseIntegrationConflictRetryCount` + `upsertIntegrationConflictRetryMarker` 复用现有 `prConflictRetryMarker` 的模式
- retryCount <= 3：回退到 `bot:pr-needs-fix`（触发 bot rebase PR 到 base branch），写 comment 标注 `integration-conflict-retry` 来源
- retryCount > 3：调用 `escalateIntegrationConflict` 走原有 escalate 路径

**Step 2: reconcile 循环增加 needs-human 恢复检查**

在 `Run()` 方法的 reconcile 流程中（integration merging 阶段之后），新增 `reconcileNeedsHumanRecovery(ctx, tasks)`：

1. 遍历所有 task，筛选同时带 `needs-human` + `integration-conflict` 标签的 issue
2. 检查冷却时间：读取 task metadata 中的 `escalated_at` 时间戳，escalate 后 5 分钟内不检查
3. 查询关联 PR 的 mergeable 状态（通过 `c.github.GetPRMergeableStatus`）
4. PR 为 MERGEABLE：清除 `needs-human` + `integration-conflict` 标签，恢复到 `bot:pr-reviewable`，写恢复日志 comment
5. PR 为 CONFLICTING 或 UNKNOWN：跳过，等下次 reconcile

### 文件变更

| 路径 | 操作 | 描述 |
|------|------|------|
| `automation/niuma/pkg/control/controller.go` | modify | 1. 在 `case MergeStatusEscalated:` (~line 948) 插入 AI 解冲突尝试：调用 tryResolveIntegrationConflictWithAI，成功则继续 gate 流程，失败走 retry/escalate。
2. 新增方法 `tryResolveIntegrationConflictWithAI(ctx, task, outcome) bool`：重新 merge 重现冲突 → collectPRConflictDetails → allowAIConflictResolution → tryResolveConflictByAIOnce → commit 或 abort。
3. 新增方法 `handleIntegrationConflictRetry(ctx, task, outcome)`：读取/更新 INTEGRATION_CONFLICT_RETRY marker，retryCount<=3 回退 bot:pr-needs-fix，>3 escalate。
4. 新增 `integrationConflictRetryMarkerRe` 正则 + `parseIntegrationConflictRetryCount` + `upsertIntegrationConflictRetryMarker` 辅助函数。
5. 新增方法 `reconcileNeedsHumanRecovery(ctx, tasks)`：在 Run() 中 integration merge 阶段之后调用，检查 needs-human + integration-conflict 的 issue，PR MERGEABLE 则自动恢复。
6. `escalateIntegrationConflict` 中写入 `escalated_at` 时间戳到 task metadata（供冷却检查）。 |
| `automation/niuma/pkg/control/controller_test.go` | modify | 新增测试覆盖：1. TestTryResolveIntegrationConflictWithAI_Success（AI 解冲突成功路径）2. TestTryResolveIntegrationConflictWithAI_Failure_Retry（AI 失败走 retry）3. TestHandleIntegrationConflictRetry_UnderThreshold（retry 回退 bot:pr-needs-fix）4. TestHandleIntegrationConflictRetry_OverThreshold（retry 超限 escalate）5. TestReconcileNeedsHumanRecovery_PRMergeable（自动恢复）6. TestReconcileNeedsHumanRecovery_PRConflicting（保持 needs-human）7. TestReconcileNeedsHumanRecovery_Cooldown（冷却期内跳过） |

### 测试场景

1. **暂态冲突 → AI 解冲突成功**: 输入 `PR B integration merge 返回 MergeStatusEscalated，冲突文件为 Go import 差异（AI 白名单内）` → 预期 `tryResolveIntegrationConflictWithAI 重新 merge → AI 解冲突 → commit → 返回 true → controller 继续走 integration gate`
2. **暂态冲突 → AI 解冲突失败 → retry 回退**: 输入 `PR B integration merge 返回 MergeStatusEscalated，冲突文件 AI 无法解决，retryCount=1` → 预期 `AI 失败 → git merge --abort → 读取 retryCount=1（<=3）→ 更新 marker 为 2 → 回退到 bot:pr-needs-fix → 写 comment 标注 integration-conflict-retry`
3. **retry 超限 → escalate**: 输入 `retryCount=4（>3），AI 也失败` → 预期 `调用 escalateIntegrationConflict → 写入 needs-human + integration-conflict 标签 + escalated_at 时间戳`
4. **needs-human 自动恢复**: 输入 `Issue 带 needs-human + integration-conflict，escalated_at 已过 5 分钟，PR mergeable=MERGEABLE` → 预期 `清除 needs-human + integration-conflict → 恢复 bot:pr-reviewable → 写恢复 comment`
5. **needs-human 冷却期内跳过**: 输入 `Issue 带 needs-human + integration-conflict，escalated_at 距今 2 分钟` → 预期 `跳过，不检查 PR 状态，等下次 reconcile`
6. **needs-human 但 PR 仍 CONFLICTING**: 输入 `Issue 带 needs-human + integration-conflict，PR mergeable=CONFLICTING` → 预期 `跳过，标签不变`


---
*方案已定稿，即将开始实现。*
<!-- PLAN_FILES:[{"path":"automation/niuma/pkg/control/controller.go","action":"modify","description":"1. 在 `case MergeStatusEscalated:` (~line 948) 插入 AI 解冲突尝试：调用 tryResolveIntegrationConflictWithAI，成功则继续 gate 流程，失败走 retry/escalate。\n2. 新增方法 `tryResolveIntegrationConflictWithAI(ctx, task, outcome) bool`：重新 merge 重现冲突 → collectPRConflictDetails → allowAIConflictResolution → tryResolveConflictByAIOnce → commit 或 abort。\n3. 新增方法 `handleIntegrationConflictRetry(ctx, task, outcome)`：读取/更新 INTEGRATION_CONFLICT_RETRY marker，retryCount\u003c=3 回退 bot:pr-needs-fix，\u003e3 escalate。\n4. 新增 `integrationConflictRetryMarkerRe` 正则 + `parseIntegrationConflictRetryCount` + `upsertIntegrationConflictRetryMarker` 辅助函数。\n5. 新增方法 `reconcileNeedsHumanRecovery(ctx, tasks)`：在 Run() 中 integration merge 阶段之后调用，检查 needs-human + integration-conflict 的 issue，PR MERGEABLE 则自动恢复。\n6. `escalateIntegrationConflict` 中写入 `escalated_at` 时间戳到 task metadata（供冷却检查）。"},{"path":"automation/niuma/pkg/control/controller_test.go","action":"modify","description":"新增测试覆盖：1. TestTryResolveIntegrationConflictWithAI_Success（AI 解冲突成功路径）2. TestTryResolveIntegrationConflictWithAI_Failure_Retry（AI 失败走 retry）3. TestHandleIntegrationConflictRetry_UnderThreshold（retry 回退 bot:pr-needs-fix）4. TestHandleIntegrationConflictRetry_OverThreshold（retry 超限 escalate）5. TestReconcileNeedsHumanRecovery_PRMergeable（自动恢复）6. TestReconcileNeedsHumanRecovery_PRConflicting（保持 needs-human）7. TestReconcileNeedsHumanRecovery_Cooldown（冷却期内跳过）"}] -->