### PR TITLE
fix: sub(#427): SeedModule 结构体扩展 + 层级验证基础设施 (L0) (#428)

### DIFF
--- a/compiler/bcc/src/arch.rs
+++ b/compiler/bcc/src/arch.rs
@@ -1703,7 +1703,7 @@ fn report_impl(
 }
 
 /// 校验 seed 中 parent 层级的合法性：无效引用和循环引用
-fn validate_parent_hierarchy(seed: &SeedSpec) -> Result<(), String> {
+pub(crate) fn validate_parent_hierarchy(seed: &SeedSpec) -> Result<(), String> {
     let known_ids: HashSet<&str> = seed.modules.iter().map(|m| m.module_id.as_str()).collect();
 
     // 检查无效 parent 引用
@@ -2358,5 +2358,39 @@ profiles:
 
         let result = validate_parent_hierarchy(&seed);
         assert!(result.is_ok());
+    }
+
+    /// 深度 parent 链：10 层嵌套正确解析且通过校验
+    #[test]
+    fn parent_deep_chain() {
+        // 构建 L0 -> L1 -> L2 -> ... -> L9 的 10 层链
+        let modules: Vec<SeedModule> = (0..10)
+            .map(|i| SeedModule {
+                module_id: format!("L{}", i),
+                display_name: None,
+                layer: None,
+                domain_kind: None,
+                parent: if i == 0 { None } else { Some(format!("L{}", i - 1)) },
+                precedence: None,
+                path_rules: None,
+            })
+            .collect();
+
+        let seed = SeedSpec {
+            version: None,
+            source_of_truth: None,
+            modules,
+            relations_expected: vec![],
+        };
+
+        // 校验通过
+        assert!(validate_parent_hierarchy(&seed).is_ok());
+
+        // 最深节点的祖先链正确（从近到远）
+        let pm = build_parent_map(&seed);
+        let ancestors = get_ancestors("L9", &pm);
+        assert_eq!(ancestors.len(), 9);
+        assert_eq!(ancestors[0], "L8");
+        assert_eq!(ancestors[8], "L0");
     }
 }


### PR DESCRIPTION
Closes #428

## Summary

## ✅ 最终方案：SeedModule 结构体扩展 + 层级验证基础设施 (L0)

### 实现方案

分 4 步实施：

1. **SeedModule 加 parent 字段**（arch.rs:72 之后）：新增 `#[serde(default)] parent: Option<String>`，放在 `domain_kind` 之后、`precedence` 之前。使用 `#[serde(default)]` 确保旧 seed 文件无需修改。

2. **新增辅助函数**（arch.rs，tests 模块之前）：
   - `pub(crate) fn build_parent_map(seed: &SeedSpec) -> HashMap<String, Option<String>>`：遍历 seed.modules，构建 module_id → parent 映射
   - `pub(crate) fn get_ancestors(module_id: &str, parent_map: &HashMap<String, Option<String>>) -> Vec<String>`：沿 parent 链向上遍历，收集祖先列表（从近到远排序）。调用方需保证无循环（由 validate_parent_hierarchy 预先校验）

3. **新增 validate_parent_hierarchy 函数**，在 matrix_impl 中 seed 解析后、map_files_to_modules 调用前（arch.rs:566）插入调用：
   - `fn validate_parent_hierarchy(seed: &SeedSpec) -> Result<(), String>`
   - 执行两项检查：
     a. **无效引用**：parent 指向的 module_id 不在 seed.modules 中 → 返回 Err
     b. **循环引用**：对每个有 parent 的模块，沿 parent 链向上遍历，用 visited HashSet 检测是否回到已访问节点 → 返回 Err
   - 不实现 path_rules 子集警告（留给后续 sub issue）
   - 不加 --skip-parent-validation flag

4. **补全现有 SeedModule 构造**：arch.rs 中 4 处直接构造 SeedModule 的地方（行 1986、1997、2048、2059）需补 `parent: None`

**关键设计决策**：
- 循环检测职责统一归 `validate_parent_hierarchy`，`get_ancestors` 仅负责收集祖先链
- L0 不实现 path_rules 子集警告，保持 scope 最小
- L0 不加 `--skip-parent-validation` CLI flag
- 所有新增函数保持 `pub(crate)` 可见性，供后续 sub issue 使用

### 文件变更

| 路径 | 操作 | 描述 |
|------|------|------|
| `compiler/bcc/src/arch.rs` | modify | 1. SeedModule 结构体新增 `#[serde(default)] parent: Option<String>` 字段（domain_kind 之后）
2. 新增 `validate_parent_hierarchy(seed: &SeedSpec) -> Result<(), String>` 函数：检测无效 parent 引用和循环引用
3. 新增 `pub(crate) fn build_parent_map(seed: &SeedSpec) -> HashMap<String, Option<String>>` 辅助函数
4. 新增 `pub(crate) fn get_ancestors(module_id: &str, parent_map: &HashMap<String, Option<String>>) -> Vec<String>` 辅助函数
5. matrix_impl 中 seed 解析后（行 566）插入 `validate_parent_hierarchy(&seed)?` 调用
6. 现有 4 处 SeedModule 构造（行 1986、1997、2048、2059）补 `parent: None`
7. tests 模块新增 5 个单元测试 |

### 测试场景

1. **基本层级解析**: 输入 `seed 包含 AGENT(无 parent) + AGENT_HISTORY(parent: AGENT) + AGENT_LOOP(parent: AGENT)` → 预期 `build_parent_map 返回正确映射，get_ancestors("AGENT_HISTORY") = ["AGENT"]`
2. **无效 parent 引用**: 输入 `模块 X 的 parent 指向不存在的 module_id` → 预期 `validate_parent_hierarchy 返回 Err，错误信息指明无效引用`
3. **循环引用检测**: 输入 `A.parent=B, B.parent=A` → 预期 `validate_parent_hierarchy 返回 Err，错误信息指明循环`
4. **多层嵌套**: 输入 `C.parent=B, B.parent=A` → 预期 `get_ancestors("C") = ["B", "A"]`
5. **向后兼容**: 输入 `现有无 parent 的 seed 文件` → 预期 `所有现有测试通过，parent 默认为 None，行为不变`


---
*方案已定稿，即将开始实现。*
<!-- PLAN_FILES:[{"path":"compiler/bcc/src/arch.rs","action":"modify","description":"1. SeedModule 结构体新增 `#[serde(default)] parent: Option\u003cString\u003e` 字段（domain_kind 之后）\n2. 新增 `validate_parent_hierarchy(seed: \u0026SeedSpec) -\u003e Result\u003c(), String\u003e` 函数：检测无效 parent 引用和循环引用\n3. 新增 `pub(crate) fn build_parent_map(seed: \u0026SeedSpec) -\u003e HashMap\u003cString, Option\u003cString\u003e\u003e` 辅助函数\n4. 新增 `pub(crate) fn get_ancestors(module_id: \u0026str, parent_map: \u0026HashMap\u003cString, Option\u003cString\u003e\u003e) -\u003e Vec\u003cString\u003e` 辅助函数\n5. matrix_impl 中 seed 解析后（行 566）插入 `validate_parent_hierarchy(\u0026seed)?` 调用\n6. 现有 4 处 SeedModule 构造（行 1986、1997、2048、2059）补 `parent: None`\n7. tests 模块新增 5 个单元测试"}] -->