### PR TITLE
fix(control): bot:pr-reviewable 未触发 DAG 子 issue 预合并

### DIFF
--- a/.github/workflows/niuma-orchestrate-reusable.yml
+++ b/.github/workflows/niuma-orchestrate-reusable.yml
@@ -25,7 +25,7 @@ on:
       label_whitelist:
         description: "issues:labeled 允许触发的标签白名单（逗号分隔）"
         required: false
-        default: "bot:orchestrate,bot:queued"
+        default: "bot:orchestrate,bot:queued,bot:pr-reviewable"
         type: string
       enable_dispatch_wakeup:
         description: "是否允许 repository_dispatch 唤醒"

--- a/.github/workflows/niuma-orchestrate.yml
+++ b/.github/workflows/niuma-orchestrate.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   orchestrate:
     if: >
-      (github.event_name == 'issues' && (github.event.label.name == 'bot:orchestrate' || github.event.label.name == 'bot:queued')) ||
+      (github.event_name == 'issues' && (github.event.label.name == 'bot:orchestrate' || github.event.label.name == 'bot:queued' || github.event.label.name == 'bot:pr-reviewable')) ||
       (github.event_name == 'repository_dispatch' && github.event.action == 'niuma.task.completed' && github.event.client_payload.event_source == 'close-after-integration-merge') ||
       (github.event_name == 'pull_request' && github.event.action == 'closed')
     uses: ./.github/workflows/niuma-orchestrate-reusable.yml
@@ -25,7 +25,7 @@ jobs:
       workflow_source_repo: ${{ github.repository }}
       workflow_source_ref: ${{ github.event.repository.default_branch }}
       repo_dir: "."
-      label_whitelist: "bot:orchestrate,bot:queued"
+      label_whitelist: "bot:orchestrate,bot:queued,bot:pr-reviewable"
       enable_dispatch_wakeup: true
       event_id: ${{ github.event.client_payload.event_id || '' }}
       dedup_window_hours: 24

--- a/automation/niuma/cmd/niuma/workflow_contract_test.go
+++ b/automation/niuma/cmd/niuma/workflow_contract_test.go
@@ -37,7 +37,7 @@ func TestWorkflowContract_ReusableWorkflowCallInputDefaults(t *testing.T) {
 	assert.Contains(t, content, "default: \".\"")
 	assert.NotContains(t, content, "build_niuma:")
 	assert.Contains(t, content, "label_whitelist:")
-	assert.Contains(t, content, "default: \"bot:orchestrate,bot:queued\"")
+	assert.Contains(t, content, "default: \"bot:orchestrate,bot:queued,bot:pr-reviewable\"")
 	assert.Contains(t, content, "enable_dispatch_wakeup:")
 	assert.Contains(t, content, "event_id:")
 	assert.Contains(t, content, "default: \"\"")

--- a/automation/niuma/pkg/control/controller.go
+++ b/automation/niuma/pkg/control/controller.go
@@ -1360,7 +1360,14 @@ func (c *Controller) shouldEnqueueIntegrationMergeTask(ctx context.Context, task
 		return false
 	}
 	issueByNumber[issueNum] = issue
-	return hasLabel(issue.Labels, "bot:pr-reviewable")
+	if !hasLabel(issue.Labels, "bot:pr-reviewable") {
+		return false
+	}
+	// 只有 DAG 子 issue（有 parent）才走预合并，独立 issue 走人工合并到 master
+	if parseParent(issue.Body) <= 0 {
+		return false
+	}
+	return true
 }
 
 // reconcilePRReviewableConflicts 协调 bot:pr-reviewable 的冲突回退逻辑。

--- a/automation/niuma/pkg/control/controller_test.go
+++ b/automation/niuma/pkg/control/controller_test.go
@@ -3061,6 +3061,38 @@ func TestShouldEnqueueIntegrationMergeTask_UsesLatestIssueLabel(t *testing.T) {
 	assert.Equal(t, []string{"bot:pr-needs-fix"}, issueByNumber[321].Labels)
 }
 
+func TestShouldEnqueueIntegrationMergeTask_DAGSubIssueAllowed(t *testing.T) {
+	mockGH := newMockGitHubOps(
+		IssueInfo{
+			Number: 428,
+			Labels: []string{"bot:pr-reviewable"},
+			Body:   "parent: #427\ndepends-on: #426",
+		},
+	)
+	ctrl := &Controller{github: mockGH}
+	issueByNumber := map[int]IssueInfo{}
+	task := Task{ID: "task-428", Metadata: map[string]string{"issue_num": "428"}}
+
+	allowed := ctrl.shouldEnqueueIntegrationMergeTask(context.Background(), task, issueByNumber)
+	assert.True(t, allowed)
+}
+
+func TestShouldEnqueueIntegrationMergeTask_IndependentIssueBlocked(t *testing.T) {
+	mockGH := newMockGitHubOps(
+		IssueInfo{
+			Number: 500,
+			Labels: []string{"bot:pr-reviewable"},
+			Body:   "## 背景\n普通 issue，无 parent",
+		},
+	)
+	ctrl := &Controller{github: mockGH}
+	issueByNumber := map[int]IssueInfo{}
+	task := Task{ID: "task-500", Metadata: map[string]string{"issue_num": "500"}}
+
+	allowed := ctrl.shouldEnqueueIntegrationMergeTask(context.Background(), task, issueByNumber)
+	assert.False(t, allowed)
+}
+
 func TestEnsureIssueCommentWithMarker_DedupByMarker(t *testing.T) {
 	mockGH := newMockGitHubOps()
 	mockGH.listCommentBodies[321] = []string{


### PR DESCRIPTION
## Summary

- orchestrate workflow 白名单加入 `bot:pr-reviewable`，使 DAG 子 issue review 通过后能唤醒 `control run` 执行 integration merge
- `shouldEnqueueIntegrationMergeTask` 增加 `parseParent` 过滤：只有有 `parent:` 的 DAG 子 issue 才走预合并，独立 issue 不受影响
- 更新 workflow contract 测试，新增 2 个单元测试

Closes #435

## Test plan

- [x] `TestShouldEnqueueIntegrationMergeTask_DAGSubIssueAllowed` — DAG 子 issue 允许预合并
- [x] `TestShouldEnqueueIntegrationMergeTask_IndependentIssueBlocked` — 独立 issue 不触发预合并
- [x] `TestWorkflowContract_ReusableWorkflowCallInputDefaults` — 白名单契约更新
- [x] `go test ./...` 全量通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)