### PR TITLE
feat: iterate后自动同步PLAN_FILES并增强可见进度 (#450)

### DIFF
--- a/automation/niuma/README.md
+++ b/automation/niuma/README.md
@@ -263,6 +263,17 @@ Gate 日志固定字段（用于与 PR checks 对账）：
 - `head_sha=<sha>`
 - `merge_sha=<sha>`（可得时输出）
 
+### Implement/Iterate 元数据代办
+
+- implement/iterate 阶段会在 issue 上写入可见进展 marker：
+  - `BOT:IMPLEMENT_PROGRESS`
+  - `BOT:ITERATE_PROGRESS`
+- iterate 完成后会自动同步 PR 描述中的 `PLAN_FILES`：
+  - 数据源：`Plan Final` marker + PR 实际 diff 文件列表
+  - 行为：仅更新/补齐 `<!-- PLAN_FILES:... -->` 注释块，不覆盖人工正文
+  - 失败处理：不阻断主流程，但会在 issue 上输出结构化告警评论，提示人工检查
+- 设计约束：PR 元数据更新由 orchestrator + GitHub client 执行，不依赖 AI 子进程直接调用 `gh pr edit`
+
 ## Discussion 协议（当前）
 
 - 讨论模式：仅 `debate_ab`

--- a/automation/niuma/pkg/agent/github_iface.go
+++ b/automation/niuma/pkg/agent/github_iface.go
@@ -34,7 +34,10 @@ type GitHubOps interface {
 	EnsureLabelsExist(ctx context.Context, labels []string) error
 
 	// PR 操作
+	GetPR(ctx context.Context, number int) (*github.PullRequest, error)
 	CreatePR(ctx context.Context, title, body, head, base string) (*github.PullRequest, error)
+	UpdatePRBody(ctx context.Context, number int, body string) error
+	ListPRFiles(ctx context.Context, number int) ([]gh.PRFile, error)
 	GetPRDiff(ctx context.Context, number int) (string, error)
 	CreatePRReview(ctx context.Context, number int, body, event string) (*github.PullRequestReview, error)
 	ListPRReviews(ctx context.Context, number int) ([]*github.PullRequestReview, error)

--- a/automation/niuma/pkg/agent/mock_github_test.go
+++ b/automation/niuma/pkg/agent/mock_github_test.go
@@ -21,6 +21,7 @@ type MockGitHub struct {
 	Markers  map[string]*gh.MarkerComment   // "type:issueNumber" → marker comment
 	PRs      []*github.PullRequest
 	PRDiffs  map[int]string                      // prNumber → diff
+	PRFiles  map[int][]gh.PRFile                 // prNumber → files
 	Reviews  map[int][]*github.PullRequestReview // prNumber → reviews
 
 	// 计数器
@@ -39,6 +40,7 @@ func NewMockGitHub() *MockGitHub {
 		Labels:   make(map[int][]string),
 		Markers:  make(map[string]*gh.MarkerComment),
 		PRDiffs:  make(map[int]string),
+		PRFiles:  make(map[int][]gh.PRFile),
 		Reviews:  make(map[int][]*github.PullRequestReview),
 	}
 }
@@ -256,6 +258,47 @@ func (m *MockGitHub) CreatePR(_ context.Context, title, body, head, base string)
 	}
 	m.PRs = append(m.PRs, pr)
 	return pr, nil
+}
+
+func (m *MockGitHub) GetPR(_ context.Context, number int) (*github.PullRequest, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.Error != nil {
+		return nil, m.Error
+	}
+	for _, pr := range m.PRs {
+		if pr.GetNumber() == number {
+			return pr, nil
+		}
+	}
+	return nil, fmt.Errorf("pr #%d not found", number)
+}
+
+func (m *MockGitHub) UpdatePRBody(_ context.Context, number int, body string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.Error != nil {
+		return m.Error
+	}
+	for _, pr := range m.PRs {
+		if pr.GetNumber() == number {
+			pr.Body = github.Ptr(body)
+			return nil
+		}
+	}
+	return fmt.Errorf("pr #%d not found", number)
+}
+
+func (m *MockGitHub) ListPRFiles(_ context.Context, number int) ([]gh.PRFile, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.Error != nil {
+		return nil, m.Error
+	}
+	return append([]gh.PRFile(nil), m.PRFiles[number]...), nil
 }
 
 func (m *MockGitHub) GetPRDiff(_ context.Context, number int) (string, error) {

--- a/automation/niuma/pkg/agent/orchestrator.go
+++ b/automation/niuma/pkg/agent/orchestrator.go
@@ -477,6 +477,7 @@ func (o *Orchestrator) DoImplement(ctx context.Context, workDir string) error {
 	if err := o.transition(ctx, state.StateImplementing); err != nil {
 		return err
 	}
+	o.upsertProgressMarker(ctx, marker.TypeImplementProgress, "diagnosis", "已进入 implementing，开始按方案执行代码改动。")
 
 	// 解析最终方案中的 FileChanges（用于 implement 后 diff 对比）
 	plannedChanges := ParseFileChangesFromComment(finalMC.Comment.GetBody())
@@ -486,6 +487,7 @@ func (o *Orchestrator) DoImplement(ctx context.Context, workDir string) error {
 	if implErr != nil {
 		// 回滚状态并通知
 		_ = o.transitionFrom(ctx, state.StateImplementing, prevState, false)
+		o.upsertProgressMarker(ctx, marker.TypeImplementProgress, "handoff", "实现失败，已回滚状态，等待下一步处理。")
 		_, _ = o.github.AddComment(ctx, o.issueNumber,
 			fmt.Sprintf("## ❌ 实现失败\n\n%s\n\n状态已回滚到 `%s`。", implErr.Error(), prevState))
 		return implErr
@@ -495,6 +497,7 @@ func (o *Orchestrator) DoImplement(ctx context.Context, workDir string) error {
 	if prNumber == 0 {
 		_, _ = o.github.AddComment(ctx, o.issueNumber,
 			"## ℹ️ 代码实现\n\nAI 执行完成，但 worktree 中无文件变更。状态已回滚。")
+		o.upsertProgressMarker(ctx, marker.TypeImplementProgress, "verify", "实现阶段无文件变更，已回滚到计划状态。")
 		_ = o.transitionFrom(ctx, state.StateImplementing, prevState, false)
 		return nil
 	}
@@ -509,6 +512,7 @@ func (o *Orchestrator) DoImplement(ctx context.Context, workDir string) error {
 	if err := o.github.CreateOrUpdateMarker(ctx, o.issueNumber, m, "PR 已创建"); err != nil {
 		return fmt.Errorf("创建 PR marker 失败: %w", err)
 	}
+	o.upsertProgressMarker(ctx, marker.TypeImplementProgress, "handoff", fmt.Sprintf("实现完成并创建 PR #%d，进入审查阶段。", prNumber))
 
 	// 转状态
 	return o.transition(ctx, state.StatePRCreated)
@@ -640,6 +644,7 @@ func (o *Orchestrator) DoIterate(ctx context.Context, prNumber int, workDir stri
 	}
 
 	// 读取 PR review 意见
+	o.upsertProgressMarker(ctx, marker.TypeIterateProgress, "diagnosis", "开始迭代修复，读取 review/gate 历史意见。")
 	reviews, err := o.github.ListPRReviews(ctx, prNumber)
 	if err != nil {
 		return fmt.Errorf("获取 PR reviews 失败: %w", err)
@@ -674,9 +679,16 @@ func (o *Orchestrator) DoIterate(ctx context.Context, prNumber int, workDir stri
 	iterateErr := o.doIterateInner(ctx, input, prNumber, workDir)
 	if iterateErr != nil {
 		_ = o.transitionFrom(ctx, state.StateIterating, prevState, false)
+		o.upsertProgressMarker(ctx, marker.TypeIterateProgress, "handoff", "迭代失败，状态已回滚，等待下一步处理。")
 		_, _ = o.github.AddComment(ctx, o.issueNumber,
 			fmt.Sprintf("## ❌ 迭代失败\n\n%s\n\n状态已回滚到 `%s`。", iterateErr.Error(), prevState))
 		return iterateErr
+	}
+
+	// 迭代后自动同步 PR 描述中的 PLAN_FILES，避免“代码已修复但元数据未闭环”。
+	if err := o.syncPRPlanFilesMarker(ctx, prNumber, finalMC.Comment.GetBody()); err != nil {
+		_, _ = o.github.AddComment(ctx, o.issueNumber,
+			fmt.Sprintf("## ⚠️ PLAN_FILES 自动同步失败\n\nPR #%d 元数据同步未完成：%v\n\n请人工检查 PR 描述中的 `PLAN_FILES`。", prNumber, err))
 	}
 
 	// 更新 PR marker revision
@@ -694,6 +706,7 @@ func (o *Orchestrator) DoIterate(ctx context.Context, prNumber int, workDir stri
 	if err := o.github.CreateOrUpdateMarker(ctx, o.issueNumber, m, "PR 已更新"); err != nil {
 		return fmt.Errorf("更新 PR marker 失败: %w", err)
 	}
+	o.upsertProgressMarker(ctx, marker.TypeIterateProgress, "handoff", fmt.Sprintf("迭代完成，PR #%d 已更新并进入下一轮审查。", prNumber))
 
 	// 转状态回 pr-created
 	return o.transition(ctx, state.StatePRCreated)

--- a/automation/niuma/pkg/agent/orchestrator_test.go
+++ b/automation/niuma/pkg/agent/orchestrator_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/biantaishabi2/Cli/automation/niuma/pkg/ai"
+	gh "github.com/biantaishabi2/Cli/automation/niuma/pkg/github"
 	"github.com/biantaishabi2/Cli/automation/niuma/pkg/marker"
 	"github.com/biantaishabi2/Cli/automation/niuma/pkg/state"
 	"github.com/google/go-github/v68/github"
@@ -703,6 +704,38 @@ func TestDoIterate_PostsOnPR(t *testing.T) {
 	for _, c := range issueComments {
 		assert.NotContains(t, c.GetBody(), "迭代修复", "issue 上不应该有迭代修复评论")
 	}
+}
+
+func TestDoIterate_AutoSyncsPlanFilesInPRBody(t *testing.T) {
+	mockAI := ai.NewMockProvider()
+	mockAI.SetExecuteResults("// 修复完成")
+
+	mockGH := NewMockGitHub()
+	mockGH.SetIssue(1, "Fix plan files", "Body")
+	mockGH.SetLabel(1, string(state.StatePRNeedsFix))
+	mockGH.SetMarker(1, &marker.Marker{
+		Type: marker.TypePlanFinal, Issue: 1, Revision: 1,
+	}, "## 最终方案\n\n<!-- PLAN_FILES:[{\"path\":\"src/a.go\",\"action\":\"modify\",\"description\":\"keep\"}] -->")
+	mockGH.SetMarker(1, &marker.Marker{
+		Type: marker.TypePRCreated, Issue: 1, Revision: 1, PR: 20,
+	}, "PR created")
+	mockGH.PRs = append(mockGH.PRs, &github.PullRequest{
+		Number: github.Ptr(20),
+		Body:   github.Ptr("Closes #1\n\n<!-- PLAN_FILES:[{\"path\":\"src/a.go\",\"action\":\"modify\",\"description\":\"keep\"}] -->"),
+	})
+	mockGH.PRFiles[20] = []gh.PRFile{
+		{Filename: "src/a.go", Status: "modified"},
+		{Filename: "src/b.go", Status: "modified"},
+	}
+
+	orch := NewOrchestrator(mockGH, mockAI, 1)
+	err := orch.DoIterate(context.Background(), 20, "/tmp/work")
+	require.NoError(t, err)
+
+	pr, err := mockGH.GetPR(context.Background(), 20)
+	require.NoError(t, err)
+	assert.Contains(t, pr.GetBody(), "src/b.go", "应自动补齐 missing PLAN_FILES 路径")
+	assert.Contains(t, pr.GetBody(), "自动同步：根据 PR 实际改动补齐")
 }
 
 func TestTransition_ImplementingWillNotDowngradeToFix(t *testing.T) {

--- a/automation/niuma/pkg/agent/pr_planfiles_sync.go
+++ b/automation/niuma/pkg/agent/pr_planfiles_sync.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var planFilesMarkerRe = regexp.MustCompile(`<!-- PLAN_FILES:(.*?) -->`)
+
+// syncPRPlanFilesMarker 将 PR body 中的 PLAN_FILES 与实际 diff 对齐。
+// 设计目标：仅维护 marker 注释块，避免覆盖人工正文。
+func (o *Orchestrator) syncPRPlanFilesMarker(ctx context.Context, prNumber int, finalPlanBody string) error {
+	pr, err := o.github.GetPR(ctx, prNumber)
+	if err != nil {
+		return fmt.Errorf("读取 PR 失败: %w", err)
+	}
+	prBody := pr.GetBody()
+	files, err := o.github.ListPRFiles(ctx, prNumber)
+	if err != nil {
+		return fmt.Errorf("读取 PR 文件列表失败: %w", err)
+	}
+	if len(files) == 0 {
+		return nil
+	}
+
+	// 合并来源：PR 现有 marker -> 最终方案 marker -> PR 实际文件
+	existing := ParseFileChangesFromComment(prBody)
+	fromFinal := ParseFileChangesFromComment(finalPlanBody)
+
+	merged := make(map[string]FileChange)
+	order := make([]string, 0, len(existing)+len(fromFinal)+len(files))
+	addIfMissing := func(fc FileChange) {
+		path := strings.TrimSpace(fc.Path)
+		if path == "" {
+			return
+		}
+		if _, ok := merged[path]; !ok {
+			order = append(order, path)
+		}
+		merged[path] = fc
+	}
+	for _, fc := range existing {
+		addIfMissing(fc)
+	}
+	for _, fc := range fromFinal {
+		addIfMissing(fc)
+	}
+
+	missing := make([]string, 0)
+	for _, f := range files {
+		path := strings.TrimSpace(f.Filename)
+		if path == "" {
+			continue
+		}
+		if _, ok := merged[path]; ok {
+			continue
+		}
+		missing = append(missing, path)
+		addIfMissing(FileChange{
+			Path:        path,
+			Action:      statusToPlanAction(f.Status),
+			Description: fmt.Sprintf("自动同步：根据 PR 实际改动补齐（status=%s）", strings.TrimSpace(f.Status)),
+		})
+	}
+	if len(missing) == 0 && len(existing) > 0 {
+		return nil
+	}
+
+	// 稳定顺序：已有顺序优先，新增按路径排序。
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		baseSet := make(map[string]struct{}, len(order)-len(missing))
+		for _, p := range order {
+			baseSet[p] = struct{}{}
+		}
+		filtered := make([]string, 0, len(order))
+		for _, p := range order {
+			if containsString(missing, p) {
+				continue
+			}
+			filtered = append(filtered, p)
+		}
+		for _, p := range missing {
+			if _, ok := baseSet[p]; ok {
+				filtered = append(filtered, p)
+			}
+		}
+		order = filtered
+	}
+
+	changes := make([]FileChange, 0, len(order))
+	for _, p := range order {
+		changes = append(changes, merged[p])
+	}
+
+	updatedBody, changed, err := upsertPlanFilesComment(prBody, changes)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	if err := o.github.UpdatePRBody(ctx, prNumber, updatedBody); err != nil {
+		return fmt.Errorf("更新 PR PLAN_FILES 失败: %w", err)
+	}
+
+	_, _ = o.github.AddComment(ctx, prNumber,
+		fmt.Sprintf("## 🧩 PLAN_FILES 已自动同步\n\n已按实际 diff 自动补齐 %d 个文件到 PR 描述中的 `PLAN_FILES`。", len(missing)))
+	return nil
+}
+
+func upsertPlanFilesComment(prBody string, changes []FileChange) (string, bool, error) {
+	if len(changes) == 0 {
+		return prBody, false, nil
+	}
+	raw, err := json.Marshal(changes)
+	if err != nil {
+		return "", false, fmt.Errorf("序列化 PLAN_FILES 失败: %w", err)
+	}
+	marker := fmt.Sprintf("<!-- PLAN_FILES:%s -->", string(raw))
+
+	if planFilesMarkerRe.MatchString(prBody) {
+		next := planFilesMarkerRe.ReplaceAllString(prBody, marker)
+		return next, next != prBody, nil
+	}
+
+	trimmed := strings.TrimRight(prBody, "\n")
+	next := strings.TrimSpace(trimmed + "\n\n" + marker + "\n")
+	return next, next != prBody, nil
+}
+
+func statusToPlanAction(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "added":
+		return "new"
+	case "removed":
+		return "delete"
+	default:
+		return "modify"
+	}
+}
+
+func containsString(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}
+

--- a/automation/niuma/pkg/agent/progress_marker.go
+++ b/automation/niuma/pkg/agent/progress_marker.go
@@ -1,0 +1,24 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/biantaishabi2/Cli/automation/niuma/pkg/marker"
+)
+
+func (o *Orchestrator) upsertProgressMarker(ctx context.Context, markerType marker.Type, phase, summary string) {
+	rev := 1
+	if existing, err := o.github.FindMarker(ctx, o.issueNumber, markerType); err == nil && existing != nil && existing.Marker != nil {
+		rev = existing.Marker.Revision + 1
+	}
+	m := &marker.Marker{
+		Type:     markerType,
+		Issue:    o.issueNumber,
+		Revision: rev,
+		Mode:     phase,
+	}
+	body := fmt.Sprintf("%s\n\n## ⏱️ 进度更新\n\n- phase: `%s`\n- summary: %s", marker.Render(m), phase, summary)
+	_ = o.github.CreateOrUpdateMarker(ctx, o.issueNumber, m, body)
+}
+

--- a/automation/niuma/pkg/github/pullrequests.go
+++ b/automation/niuma/pkg/github/pullrequests.go
@@ -9,6 +9,12 @@ import (
 	"github.com/google/go-github/v68/github"
 )
 
+// PRFile 表示 PR 中一个变更文件（用于 plan_files 自动同步）。
+type PRFile struct {
+	Filename string
+	Status   string
+}
+
 // GetPR 获取指定 Pull Request
 func (c *Client) GetPR(ctx context.Context, number int) (*github.PullRequest, error) {
 	pr, _, err := c.gh.PullRequests.Get(ctx, c.owner, c.repo, number)
@@ -16,6 +22,17 @@ func (c *Client) GetPR(ctx context.Context, number int) (*github.PullRequest, er
 		return nil, fmt.Errorf("获取 PR #%d 失败: %w", number, err)
 	}
 	return pr, nil
+}
+
+// UpdatePRBody 更新 PR 描述正文。
+func (c *Client) UpdatePRBody(ctx context.Context, number int, body string) error {
+	_, _, err := c.gh.PullRequests.Edit(ctx, c.owner, c.repo, number, &github.PullRequest{
+		Body: github.Ptr(body),
+	})
+	if err != nil {
+		return fmt.Errorf("更新 PR #%d body 失败: %w", number, err)
+	}
+	return nil
 }
 
 // CreatePR 创建 Pull Request
@@ -85,6 +102,30 @@ func (c *Client) ListPRReviews(ctx context.Context, number int) ([]*github.PullR
 	}
 
 	return allReviews, nil
+}
+
+// ListPRFiles 列出 PR 当前变更文件（用于 PLAN_FILES 与实际 diff 对齐）。
+func (c *Client) ListPRFiles(ctx context.Context, number int) ([]PRFile, error) {
+	var out []PRFile
+	opts := &github.ListOptions{PerPage: 100}
+
+	for {
+		files, resp, err := c.gh.PullRequests.ListFiles(ctx, c.owner, c.repo, number, opts)
+		if err != nil {
+			return nil, fmt.Errorf("列出 PR #%d files 失败: %w", number, err)
+		}
+		for _, f := range files {
+			out = append(out, PRFile{
+				Filename: f.GetFilename(),
+				Status:   f.GetStatus(),
+			})
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return out, nil
 }
 
 // ListPRCommitMessages 列出 PR 中所有 commit message（含标题+正文）

--- a/automation/niuma/pkg/marker/marker.go
+++ b/automation/niuma/pkg/marker/marker.go
@@ -21,6 +21,8 @@ const (
 	TypeDiscussionRoundLimitNotice Type = "BOT:DISCUSSION_ROUND_LIMIT_NOTICE"
 	TypeLabelGuard                 Type = "BOT:LABEL_GUARD"
 	TypeGateRetry                  Type = "BOT:GATE_RETRY"
+	TypeImplementProgress          Type = "BOT:IMPLEMENT_PROGRESS"
+	TypeIterateProgress            Type = "BOT:ITERATE_PROGRESS"
 )
 
 // AllTypes 返回所有有效的 Marker 类型
@@ -33,6 +35,8 @@ var AllTypes = []Type{
 	TypeDiscussionRoundLimitNotice,
 	TypeLabelGuard,
 	TypeGateRetry,
+	TypeImplementProgress,
+	TypeIterateProgress,
 }
 
 // Marker 表示一个嵌入在 GitHub 评论中的幂等标记

--- a/automation/niuma/tests/integration/discuss_flow_test.go
+++ b/automation/niuma/tests/integration/discuss_flow_test.go
@@ -202,6 +202,18 @@ func (m *flowGitHubMock) CreatePR(_ context.Context, _, _, _, _ string) (*ghapi.
 	return nil, fmt.Errorf("unexpected CreatePR call")
 }
 
+func (m *flowGitHubMock) GetPR(_ context.Context, _ int) (*ghapi.PullRequest, error) {
+	return nil, fmt.Errorf("unexpected GetPR call")
+}
+
+func (m *flowGitHubMock) UpdatePRBody(_ context.Context, _ int, _ string) error {
+	return fmt.Errorf("unexpected UpdatePRBody call")
+}
+
+func (m *flowGitHubMock) ListPRFiles(_ context.Context, _ int) ([]gh.PRFile, error) {
+	return nil, nil
+}
+
 func (m *flowGitHubMock) GetPRDiff(_ context.Context, _ int) (string, error) {
 	return "", nil
 }


### PR DESCRIPTION
## Summary
- 迭代完成后自动对齐 PR body 中的 PLAN_FILES 与实际 diff
- implement/iterate 增加可见进度 marker（diagnosis/handoff）
- 补充 PR 元数据读写接口与对应测试

## Test plan
- go test ./pkg/marker ./pkg/agent/... ./pkg/github ./tests/integration/...
- 在 Cli-niuma-test 对 #204/#205 实测 iterate，确认自动写入 PLAN_FILES

Closes #450