### PR TITLE
fix(niuma): integration 合入后推送远端分支 (#462)

### DIFF
--- a/automation/niuma/pkg/control/controller.go
+++ b/automation/niuma/pkg/control/controller.go
@@ -2128,6 +2128,13 @@ func (c *Controller) runIntegrationGateAndDecide(ctx context.Context, task Task,
 	if err := c.markIntegrationGatePassed(task, attemptKey); err != nil {
 		return false, err
 	}
+	// builder 为空时（如单测注入最小 controller）跳过 push；
+	// 生产 orchestrate 路径会注入 builder 并执行远端同步。
+	if c.builder != nil {
+		if err := c.builder.PushBranch(outcome.IntegrationBranch); err != nil {
+			return false, err
+		}
+	}
 	if err := c.markTaskIntegrated(task, outcome); err != nil {
 		return false, err
 	}

--- a/automation/niuma/pkg/control/integration.go
+++ b/automation/niuma/pkg/control/integration.go
@@ -103,6 +103,20 @@ func (b *IntegrationBuilder) MergeOne(integrationBranch string, bi BranchInfo, s
 	return nil
 }
 
+// PushBranch 将 integration 分支推送到远端 origin。
+// 约束：branch 不能为空。
+func (b *IntegrationBuilder) PushBranch(branch string) error {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return fmt.Errorf("integration 分支名为空，无法推送")
+	}
+
+	if err := b.git("push", "-u", "origin", branch); err != nil {
+		return fmt.Errorf("推送 %s 失败: %w", branch, err)
+	}
+	return nil
+}
+
 // ExecuteIntegrationMerge 执行统一 integration 合并流程。
 // 结果分为 merged / auto_resolved / escalated。
 // startPoint: 非空时传给 EnsureBranch 作为创建起点

--- a/automation/niuma/pkg/control/integration_test.go
+++ b/automation/niuma/pkg/control/integration_test.go
@@ -30,6 +30,19 @@ func setupGitRepo(t *testing.T) string {
 	return dir
 }
 
+// setupGitRepoWithBareRemote 创建带 bare origin 的测试仓库，返回工作仓库路径与远端路径。
+func setupGitRepoWithBareRemote(t *testing.T) (string, string) {
+	t.Helper()
+
+	remoteDir := filepath.Join(t.TempDir(), "origin.git")
+	runGit(t, "", "init", "--bare", remoteDir)
+
+	workDir := setupGitRepo(t)
+	runGit(t, workDir, "remote", "add", "origin", remoteDir)
+	runGit(t, workDir, "push", "-u", "origin", "master")
+	return workDir, remoteDir
+}
+
 // createBranch 在仓库中创建分支并添加文件
 func createBranch(t *testing.T, dir, branch, filename, content string) {
 	t.Helper()
@@ -222,6 +235,37 @@ func TestIntegrationBuilder_ExecuteIntegrationMerge_AutoResolvedForWhitelistedFi
 
 	content := runGitOutput(t, dir, "show", "integration/test-auto:docs/guide.md")
 	assert.Contains(t, content, "line from B")
+}
+
+func TestIntegrationBuilder_PushBranch_Success(t *testing.T) {
+	dir, remoteDir := setupGitRepoWithBareRemote(t)
+	createBranch(t, dir, "feat/40-auth", "auth.go", "package auth\n")
+
+	builder := NewIntegrationBuilder(dir, "master")
+	outcome, err := builder.ExecuteIntegrationMerge("integration/main", BranchInfo{
+		Branch:   "feat/40-auth",
+		IssueNum: 40,
+		PRNum:    400,
+	}, "")
+	require.NoError(t, err)
+	assert.Equal(t, MergeStatusMerged, outcome.Status)
+
+	err = builder.PushBranch("integration/main")
+	require.NoError(t, err)
+
+	cmd := exec.Command("git", "--git-dir", remoteDir, "rev-parse", "refs/heads/integration/main")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.NotEmpty(t, strings.TrimSpace(string(out)))
+}
+
+func TestIntegrationBuilder_PushBranch_EmptyBranch(t *testing.T) {
+	dir := setupGitRepo(t)
+	builder := NewIntegrationBuilder(dir, "master")
+
+	err := builder.PushBranch("   ")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "分支名为空")
 }
 
 func TestIntegrationBuilder_ExecuteIntegrationMerge_EscalatedForCoreSemanticConflict(t *testing.T) {


### PR DESCRIPTION
## Summary
- 在 IntegrationBuilder 新增 `PushBranch`，用于将 `integration/*` 推送到 origin
- 在 gate 通过后、标记 integrated 前执行 push，避免本地成功但远端缺失
- 新增推送相关测试（成功推送、空分支参数校验）

## Test plan
- `cd automation/niuma && go test ./pkg/control/...`

Closes #462
