### PR TITLE
fix(niuma): integration 分支优先跟踪远端基线 (#464)

### DIFF
--- a/automation/niuma/pkg/control/integration.go
+++ b/automation/niuma/pkg/control/integration.go
@@ -69,6 +69,15 @@ func (b *IntegrationBuilder) EnsureBranch(branchName, startPoint string) (string
 		return branchName, nil
 	}
 
+	// 远端已存在时，优先基于 origin/<branchName> 创建本地分支，
+	// 确保 integration 历史连续，避免 push non-fast-forward。
+	if b.remoteBranchExists(branchName) {
+		if err := b.git("branch", branchName, "origin/"+branchName); err != nil {
+			return "", fmt.Errorf("基于远端分支创建 %s 失败: %w", branchName, err)
+		}
+		return branchName, nil
+	}
+
 	// 决定创建起点
 	base := b.baseBranch
 	if startPoint != "" {
@@ -978,4 +987,13 @@ func (b *IntegrationBuilder) gitOutput(args ...string) (string, error) {
 		return "", fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, string(out))
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// remoteBranchExists 检查 origin/<branch> 是否存在。
+func (b *IntegrationBuilder) remoteBranchExists(branch string) bool {
+	if strings.TrimSpace(branch) == "" {
+		return false
+	}
+	out, err := b.gitOutput("branch", "--list", "--remote", "origin/"+branch)
+	return err == nil && strings.TrimSpace(out) != ""
 }

--- a/automation/niuma/pkg/control/integration_test.go
+++ b/automation/niuma/pkg/control/integration_test.go
@@ -268,6 +268,53 @@ func TestIntegrationBuilder_PushBranch_EmptyBranch(t *testing.T) {
 	assert.Contains(t, err.Error(), "分支名为空")
 }
 
+func TestIntegrationBuilder_EnsureBranch_UsesRemoteIntegrationAsBase(t *testing.T) {
+	// 第一次：在 repo A 中完成一轮 integration 合入并推送。
+	repoA, remoteDir := setupGitRepoWithBareRemote(t)
+	createBranch(t, repoA, "feat/40-auth", "auth.go", "package auth\n")
+	runGit(t, repoA, "push", "-u", "origin", "feat/40-auth")
+
+	builderA := NewIntegrationBuilder(repoA, "master")
+	outcomeA, err := builderA.ExecuteIntegrationMerge("integration/main", BranchInfo{
+		Branch:   "feat/40-auth",
+		IssueNum: 40,
+		PRNum:    400,
+	}, "")
+	require.NoError(t, err)
+	assert.Equal(t, MergeStatusMerged, outcomeA.Status)
+	require.NoError(t, builderA.PushBranch("integration/main"))
+
+	// 第二次：在 repo B（新工作目录）中继续合入下一条分支。
+	repoB := filepath.Join(t.TempDir(), "repo-b")
+	runGit(t, "", "clone", remoteDir, repoB)
+	runGit(t, repoB, "config", "user.email", "test@test.com")
+	runGit(t, repoB, "config", "user.name", "Test")
+
+	createBranch(t, repoB, "feat/41-payment", "payment.go", "package payment\n")
+	runGit(t, repoB, "push", "-u", "origin", "feat/41-payment")
+
+	builderB := NewIntegrationBuilder(repoB, "master")
+	outcomeB, err := builderB.ExecuteIntegrationMerge("integration/main", BranchInfo{
+		Branch:   "feat/41-payment",
+		IssueNum: 41,
+		PRNum:    401,
+	}, "")
+	require.NoError(t, err)
+	assert.Equal(t, MergeStatusMerged, outcomeB.Status)
+	require.NoError(t, builderB.PushBranch("integration/main"))
+
+	// 验证远端 integration/main 已连续包含两次合入结果。
+	cmd := exec.Command("git", "--git-dir", remoteDir, "show", "refs/heads/integration/main:auth.go")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Contains(t, string(out), "package auth")
+
+	cmd = exec.Command("git", "--git-dir", remoteDir, "show", "refs/heads/integration/main:payment.go")
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Contains(t, string(out), "package payment")
+}
+
 func TestIntegrationBuilder_ExecuteIntegrationMerge_EscalatedForCoreSemanticConflict(t *testing.T) {
 	dir := setupGitRepo(t)
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "pkg"), 0o755))


### PR DESCRIPTION
## Summary
- `EnsureBranch` 新增远端优先策略：若存在 `origin/integration/*`，本地 integration 分支基于远端创建
- 避免本地从 `master/startPoint` 重建导致与远端分叉，引发 push non-fast-forward
- 补充跨工作目录二次合入回归测试（模拟 #26 后继续合 #27）

## Test plan
- `cd automation/niuma && go test ./pkg/control/...`

Closes #464
