### PR TITLE
fix: DAG implement should target integration base (#466)

### DIFF
--- a/automation/niuma/pkg/agent/orchestrator.go
+++ b/automation/niuma/pkg/agent/orchestrator.go
@@ -36,8 +36,8 @@ type OrchestratorConfig struct {
 	MaxDiscussionRounds int  // discuss 单次 run 内最大轮数（0=默认5）
 
 	// plan-final 重试与降级
-	PlanFinalProviders []ai.Provider // 降级 provider 列表（为空则使用默认 provider）
-	PlanFinalMaxRetries int          // 每个 provider 的重试次数（0=默认1）
+	PlanFinalProviders  []ai.Provider // 降级 provider 列表（为空则使用默认 provider）
+	PlanFinalMaxRetries int           // 每个 provider 的重试次数（0=默认1）
 
 	// review 重试与降级
 	ReviewProviders  []ai.Provider // review 降级 provider 列表（为空则使用 ImplementProvider）
@@ -527,11 +527,12 @@ func (o *Orchestrator) doImplementInner(ctx context.Context, input *PromptInput,
 	var branchName string
 
 	var cleanupWorktree func() // worktree 清理函数（失败时调用）
+	implementBaseBranch := selectImplementBaseBranch(input.IssueBody)
 	if o.config != nil && o.config.RepoDir != "" {
 		// 使用 worktree 隔离
 		ws := NewWorkspace(o.config.RepoDir)
 		slug := slugFromTitle(input.IssueTitle)
-		wtPath, err := ws.Create(o.issueNumber, slug)
+		wtPath, err := ws.Create(o.issueNumber, slug, implementBaseBranch)
 		if err != nil {
 			return 0, fmt.Errorf("创建 worktree 失败: %w", err)
 		}
@@ -580,7 +581,7 @@ func (o *Orchestrator) doImplementInner(ctx context.Context, input *PromptInput,
 
 			prTitle := fmt.Sprintf("fix: %s (#%d)", input.IssueTitle, o.issueNumber)
 			prBody := fmt.Sprintf("Closes #%d\n\n## Summary\n\n%s", o.issueNumber, input.FinalPlan)
-			pr, err := o.github.CreatePR(ctx, prTitle, prBody, branchName, "master")
+			pr, err := o.github.CreatePR(ctx, prTitle, prBody, branchName, implementBaseBranch)
 			if err != nil {
 				return 0, fmt.Errorf("创建 PR 失败: %w", err)
 			}
@@ -947,11 +948,11 @@ func (o *Orchestrator) currentState(ctx context.Context) (state.State, error) {
 				_, _ = o.github.AddComment(ctx, o.issueNumber,
 					"## ⚠️ 状态自愈失败\n\n检测到多个 `bot:*` 状态标签，自动收敛失败，请人工处理后重试。")
 				return "", nerr
-				}
-				if changed {
-					marker := fmt.Sprintf("<!-- BOT:STATE_CONVERGED issue=%d target=%s -->", o.issueNumber, target)
-					comments, _ := o.github.ListComments(ctx, o.issueNumber)
-					duplicated := false
+			}
+			if changed {
+				marker := fmt.Sprintf("<!-- BOT:STATE_CONVERGED issue=%d target=%s -->", o.issueNumber, target)
+				comments, _ := o.github.ListComments(ctx, o.issueNumber)
+				duplicated := false
 				for _, c := range comments {
 					if strings.Contains(c.GetBody(), marker) {
 						duplicated = true
@@ -1257,6 +1258,25 @@ func slugFromTitle(title string) string {
 		slug = slug[:30]
 	}
 	return slug
+}
+
+// selectImplementBaseBranch 根据 issue body 选择 implement 阶段的基线分支。
+// DAG 子 issue（包含 parent:）走 integration/main，其余保持 master。
+func selectImplementBaseBranch(issueBody string) string {
+	if hasParentDirective(issueBody) {
+		return "integration/main"
+	}
+	return "master"
+}
+
+func hasParentDirective(issueBody string) bool {
+	for _, line := range strings.Split(issueBody, "\n") {
+		trimmed := strings.TrimSpace(strings.ToLower(line))
+		if strings.HasPrefix(trimmed, "parent:") {
+			return true
+		}
+	}
+	return false
 }
 
 // recoverableKind 从 error 中提取 RecoverableErrorKind，未匹配时返回 "Unknown"

--- a/automation/niuma/pkg/agent/orchestrator_test.go
+++ b/automation/niuma/pkg/agent/orchestrator_test.go
@@ -5,6 +5,9 @@ package agent
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -175,7 +178,7 @@ func TestDoIterate_WithWorktree(t *testing.T) {
 
 	// 先创建 worktree（模拟 implement 阶段已创建）
 	ws := NewWorkspace(repoDir)
-	_, err := ws.Create(1, "login")
+	_, err := ws.Create(1, "login", "")
 	require.NoError(t, err)
 	require.True(t, ws.Exists(1))
 
@@ -205,6 +208,81 @@ func TestDoIterate_WithWorktree(t *testing.T) {
 	expectedWT := ws.Path(1)
 	assert.Equal(t, expectedWT, mockAI.LastWorkDir())
 	assert.Contains(t, expectedWT, ".worktrees/fix-1")
+}
+
+type writeFileProvider struct {
+	repoDir   string
+	issueNum  int
+	fileName  string
+	writeBody string
+}
+
+func (p *writeFileProvider) Name() string { return "write-file-provider" }
+
+func (p *writeFileProvider) Complete(_ context.Context, _ string, _ ...ai.Option) (string, error) {
+	return "unused", nil
+}
+
+func (p *writeFileProvider) Execute(_ context.Context, _ string, _ ...ai.Option) (string, error) {
+	wtPath := NewWorkspace(p.repoDir).Path(p.issueNum)
+	if err := os.WriteFile(filepath.Join(wtPath, p.fileName), []byte(p.writeBody), 0644); err != nil {
+		return "", err
+	}
+	return "file written", nil
+}
+
+func TestDoImplement_SubIssueCreatePR_BaseIntegrationMain(t *testing.T) {
+	repoDir := initTestRepo(t)
+	git := gitBin()
+	remoteDir := filepath.Join(t.TempDir(), "remote.git")
+
+	// 预置 integration/main 分支，确保 DAG 子 issue 可从该基线创建 worktree。
+	cmd := exec.Command(git, "init", "--bare", remoteDir)
+	require.NoError(t, cmd.Run())
+	cmd = exec.Command(git, "remote", "add", "origin", remoteDir)
+	cmd.Dir = repoDir
+	require.NoError(t, cmd.Run())
+	cmd = exec.Command(git, "push", "-u", "origin", "master")
+	cmd.Dir = repoDir
+	require.NoError(t, cmd.Run())
+
+	cmd = exec.Command(git, "checkout", "-b", "integration/main")
+	cmd.Dir = repoDir
+	require.NoError(t, cmd.Run())
+	cmd = exec.Command(git, "push", "-u", "origin", "integration/main")
+	cmd.Dir = repoDir
+	require.NoError(t, cmd.Run())
+	cmd = exec.Command(git, "checkout", "master")
+	cmd.Dir = repoDir
+	require.NoError(t, cmd.Run())
+
+	mockGH := NewMockGitHub()
+	mockGH.SetIssue(1, "Fix gateway chain", "parent: #24\ndepends-on: #26")
+	mockGH.SetLabel(1, string(state.StatePlanFinal))
+	mockGH.SetMarker(1, &marker.Marker{
+		Type: marker.TypePlanFinal, Issue: 1, Revision: 1,
+	}, "最终方案内容")
+
+	orch := NewOrchestratorWithConfig(mockGH, 1, &OrchestratorConfig{
+		ImplementProvider: &writeFileProvider{
+			repoDir:   repoDir,
+			issueNum:  1,
+			fileName:  "sub_issue_change.txt",
+			writeBody: "changed",
+		},
+		RepoDir: repoDir,
+	})
+
+	err := orch.DoImplement(context.Background(), "/tmp/fallback")
+	require.NoError(t, err)
+	require.NotEmpty(t, mockGH.PRs)
+	assert.Equal(t, "integration/main", mockGH.PRs[0].GetBase().GetRef())
+}
+
+func TestSelectImplementBaseBranch(t *testing.T) {
+	assert.Equal(t, "master", selectImplementBaseBranch("no parent"))
+	assert.Equal(t, "integration/main", selectImplementBaseBranch("parent: #24"))
+	assert.Equal(t, "integration/main", selectImplementBaseBranch("  Parent: #99  "))
 }
 
 func TestDoIterate_HappyPath(t *testing.T) {

--- a/automation/niuma/pkg/agent/workspace.go
+++ b/automation/niuma/pkg/agent/workspace.go
@@ -26,8 +26,8 @@ func NewWorkspace(repoDir string) *Workspace {
 }
 
 // Create 创建 worktree 并切出新分支
-// 返回 worktree 的绝对路径
-func (w *Workspace) Create(issueNum int, slug string) (string, error) {
+// base 为空时默认使用 master，返回 worktree 的绝对路径
+func (w *Workspace) Create(issueNum int, slug, base string) (string, error) {
 	wtPath := w.Path(issueNum)
 	branch := w.branchName(issueNum, slug)
 
@@ -41,17 +41,14 @@ func (w *Workspace) Create(issueNum int, slug string) (string, error) {
 		return "", fmt.Errorf("创建 .worktrees 目录失败: %w", err)
 	}
 
-	// 确保 base 是最新的：有 origin 时用 origin/master，否则用本地 master
-	base := "master"
-	if w.hasOrigin() {
-		if err := w.fetchRef("master"); err != nil {
-			return "", fmt.Errorf("fetch master 失败: %w", err)
-		}
-		base = "origin/master"
+	// 解析创建分支的基线；有 origin 时优先使用 origin/<base>
+	baseRef, err := w.resolveWorktreeBaseRef(base)
+	if err != nil {
+		return "", err
 	}
 
 	// 基于 base 创建新分支的 worktree
-	cmd := exec.Command("git", "worktree", "add", "-b", branch, wtPath, base)
+	cmd := exec.Command("git", "worktree", "add", "-b", branch, wtPath, baseRef)
 	cmd.Dir = w.RepoDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -178,6 +175,30 @@ func (w *Workspace) branchName(issueNum int, slug string) string {
 	return fmt.Sprintf("fix/%d-%s", issueNum, slug)
 }
 
+// resolveWorktreeBaseRef 解析 worktree 创建时使用的基线引用。
+// 有 origin 时优先 fetch 并使用 origin/<base>，否则回退到本地分支。
+func (w *Workspace) resolveWorktreeBaseRef(base string) (string, error) {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		base = "master"
+	}
+
+	if w.hasOrigin() {
+		if err := w.fetchRef(base); err == nil {
+			return "origin/" + base, nil
+		}
+		if w.branchExists(base) {
+			return base, nil
+		}
+		return "", fmt.Errorf("基线分支不存在: %s", base)
+	}
+
+	if !w.branchExists(base) {
+		return "", fmt.Errorf("基线分支不存在: %s", base)
+	}
+	return base, nil
+}
+
 // hasOrigin 检查是否存在 origin remote
 func (w *Workspace) hasOrigin() bool {
 	cmd := exec.Command("git", "remote", "get-url", "origin")
@@ -194,4 +215,11 @@ func (w *Workspace) fetchRef(ref string) error {
 		return fmt.Errorf("git fetch origin %s: %w\n%s", ref, err, string(out))
 	}
 	return nil
+}
+
+// branchExists 检查本地分支是否存在。
+func (w *Workspace) branchExists(branch string) bool {
+	cmd := exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	cmd.Dir = w.RepoDir
+	return cmd.Run() == nil
 }

--- a/automation/niuma/pkg/agent/workspace_test.go
+++ b/automation/niuma/pkg/agent/workspace_test.go
@@ -72,13 +72,13 @@ func TestWorkspace_CreateAndRemove(t *testing.T) {
 	ws := NewWorkspace(repoDir)
 
 	// 创建 worktree（默认从 master）
-	wtPath, err := ws.Create(1, "test-fix")
+	wtPath, err := ws.Create(1, "test-fix", "")
 	require.NoError(t, err)
 	assert.DirExists(t, wtPath)
 	assert.True(t, ws.Exists(1))
 
 	// 重复创建应幂等
-	wtPath2, err := ws.Create(1, "test-fix")
+	wtPath2, err := ws.Create(1, "test-fix", "")
 	require.NoError(t, err)
 	assert.Equal(t, wtPath, wtPath2)
 
@@ -90,6 +90,44 @@ func TestWorkspace_CreateAndRemove(t *testing.T) {
 	// 重复移除应幂等
 	err = ws.Remove(1)
 	require.NoError(t, err)
+}
+
+func TestWorkspace_CreateWithIntegrationBase(t *testing.T) {
+	repoDir := initTestRepo(t)
+	ws := NewWorkspace(repoDir)
+	git := gitBin()
+
+	// 准备 integration/main 分支，并写入仅该分支存在的文件。
+	cmd := exec.Command(git, "checkout", "-b", "integration/main")
+	cmd.Dir = repoDir
+	require.NoError(t, cmd.Run())
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "INTEGRATION_ONLY.txt"), []byte("from integration"), 0644))
+	cmd = exec.Command(git, "add", "INTEGRATION_ONLY.txt")
+	cmd.Dir = repoDir
+	require.NoError(t, cmd.Run())
+	cmd = exec.Command(git, "commit", "-m", "integration base commit")
+	cmd.Dir = repoDir
+	require.NoError(t, cmd.Run())
+
+	// 回到 master，确保 master 上没有该文件。
+	cmd = exec.Command(git, "checkout", "master")
+	cmd.Dir = repoDir
+	require.NoError(t, cmd.Run())
+	_, err := os.Stat(filepath.Join(repoDir, "INTEGRATION_ONLY.txt"))
+	assert.True(t, os.IsNotExist(err))
+
+	wtPath, err := ws.Create(2, "from-integration", "integration/main")
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(wtPath, "INTEGRATION_ONLY.txt"))
+}
+
+func TestWorkspace_CreateWithMissingBase_ReturnsError(t *testing.T) {
+	repoDir := initTestRepo(t)
+	ws := NewWorkspace(repoDir)
+
+	_, err := ws.Create(3, "missing-base", "integration/not-exists")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "基线分支不存在")
 }
 
 func TestWorkspace_Checkout(t *testing.T) {


### PR DESCRIPTION
Closes #466

## Summary

- `Workspace.Create` 新增 `base` 参数，支持按指定基线创建 worktree 分支（默认 `master`）。
- Implement 阶段新增基线选择逻辑：检测 issue body 含 `parent:` 时，分支与 PR base 都使用 `integration/main`；否则保持 `master`。
- 保持非 DAG issue 行为不变。

## Test plan

- `cd automation/niuma && go test ./pkg/agent/...`
- 新增用例覆盖：
  - `Workspace` 从 `integration/main` 建分支
  - `Workspace` 基线分支不存在报错
  - DAG 子 issue 的 PR base 为 `integration/main`
  - 基线选择函数 `selectImplementBaseBranch`
