### PR TITLE
fix(niuma): allow close-merged on integration base refs

### DIFF
--- a/automation/niuma/cmd/niuma/control.go
+++ b/automation/niuma/cmd/niuma/control.go
@@ -713,8 +713,8 @@ func runControlCloseMerged(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	baseRef := pr.GetBase().GetRef()
-	if baseRef != "master" {
-		fmt.Printf("PR #%d base=%s 非 master，跳过收口。\n", flagPR, baseRef)
+	if !isCloseMergedBaseRef(baseRef) {
+		fmt.Printf("PR #%d base=%s 非 master/integration/*，跳过收口。\n", flagPR, baseRef)
 		return nil
 	}
 
@@ -744,6 +744,16 @@ func runControlCloseMerged(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// isCloseMergedBaseRef 判断 close-merged 是否应执行收口。
+// 当前允许 master 与 integration/*，覆盖 DAG 子任务先合入 integration 再收口的路径。
+func isCloseMergedBaseRef(baseRef string) bool {
+	baseRef = strings.TrimSpace(baseRef)
+	if baseRef == "master" {
+		return true
+	}
+	return strings.HasPrefix(baseRef, "integration/")
 }
 
 // handleCloseMergedDispatch 处理 close-merged 的 dispatch-wakeup 逻辑。

--- a/automation/niuma/cmd/niuma/control_test.go
+++ b/automation/niuma/cmd/niuma/control_test.go
@@ -568,6 +568,16 @@ func TestDispatchTaskCompleted_TimestampFallback(t *testing.T) {
 	assert.Equal(t, "timestamp", sender.payload["event_id_source"])
 }
 
+func TestIsCloseMergedBaseRef(t *testing.T) {
+	assert.True(t, isCloseMergedBaseRef("master"))
+	assert.True(t, isCloseMergedBaseRef("integration/main"))
+	assert.True(t, isCloseMergedBaseRef("integration/feature-x"))
+	assert.True(t, isCloseMergedBaseRef(" integration/main "))
+	assert.False(t, isCloseMergedBaseRef("main"))
+	assert.False(t, isCloseMergedBaseRef("feature/foo"))
+	assert.False(t, isCloseMergedBaseRef(""))
+}
+
 type stubGitHubControlClient struct {
 	findMarkerResp *gh.MarkerComment
 	findMarkerErr  error


### PR DESCRIPTION
## Summary
- allow `niuma control close-merged` to finalize when PR base ref is `integration/*` in addition to `master`
- keep existing behavior for non-integration branches (skip finalization)
- add focused unit test for base-ref predicate

## Test plan
- `cd automation/niuma`
- `go test ./cmd/niuma -run 'TestIsCloseMergedBaseRef|TestExtractIntegratedIssueNumbers'`

Closes #479
