### PR TITLE
fix: 修复 niuma self-check gate 重试与状态流转语义

### DIFF
--- a/.github/workflows/niuma-implement-reusable.yml
+++ b/.github/workflows/niuma-implement-reusable.yml
@@ -142,7 +142,7 @@ jobs:
             if "$NIUMA_BIN" gate run \
                  --repo "$REPO" --issue "$ISSUE_NUMBER" \
                  --pr "$PR_NUMBER" --repo-dir "$WORKSPACE" \
-                 --max-retries "$MAX_RETRIES" --self-check; then
+                 --max-retries 0 --self-check; then
               echo "Gate passed on attempt $ATTEMPT"
               exit 0
             fi
@@ -157,6 +157,14 @@ jobs:
             fi
 
             echo "Gate failed (attempt $ATTEMPT/$MAX_RETRIES), running iterate..."
+            "$NIUMA_BIN" state-label set \
+              --repo "$REPO" --issue "$ISSUE_NUMBER" \
+              --from bot:pr-created --to bot:pr-needs-fix \
+              || "$NIUMA_BIN" state-label set \
+                --repo "$REPO" --issue "$ISSUE_NUMBER" \
+                --to bot:pr-needs-fix \
+              || true
+
             "$NIUMA_BIN" iterate \
               --repo "$REPO" --issue "$ISSUE_NUMBER" \
               --pr "$PR_NUMBER" --repo-dir "$WORKSPACE" || true

--- a/automation/niuma/cmd/niuma/gate_run.go
+++ b/automation/niuma/cmd/niuma/gate_run.go
@@ -34,7 +34,9 @@ func init() {
 	gateRunCmd.Flags().BoolVar(&flagGateSelfCheck, "self-check", false, "self-check 模式：gate 失败时不设标签/不写 issue 评论，仅写 PR review")
 }
 
-// parseMaxRetries 将 string 解析为 int，解析失败回退默认值 2，值 ≤0 clamp 到 1。
+// parseMaxRetries 将 string 解析为 int，解析失败回退默认值 2。
+// 值为 0 表示禁用自动重试（仅执行一次 gate）。
+// 负值会被 clamp 到 0。
 func parseMaxRetries(raw string) int {
 	const defaultVal = 2
 	n, err := strconv.Atoi(raw)
@@ -42,9 +44,9 @@ func parseMaxRetries(raw string) int {
 		fmt.Fprintf(os.Stderr, "WARNING: --max-retries 值 '%s' 非法，回退为 %d\n", raw, defaultVal)
 		return defaultVal
 	}
-	if n <= 0 {
-		fmt.Fprintf(os.Stderr, "WARNING: --max-retries 值 %d ≤ 0，clamp 到 1\n", n)
-		return 1
+	if n < 0 {
+		fmt.Fprintf(os.Stderr, "WARNING: --max-retries 值 %d < 0，clamp 到 0\n", n)
+		return 0
 	}
 	return n
 }

--- a/automation/niuma/cmd/niuma/gate_run_test.go
+++ b/automation/niuma/cmd/niuma/gate_run_test.go
@@ -56,16 +56,15 @@ func TestParseMaxRetries_EmptyInput(t *testing.T) {
 func TestParseMaxRetries_ZeroInput(t *testing.T) {
 	stderr := captureStderr(t, func() {
 		result := parseMaxRetries("0")
-		assert.Equal(t, 1, result, "零值输入应 clamp 到 1")
+		assert.Equal(t, 0, result, "零值输入应保留为 0（禁用自动重试）")
 	})
-	assert.True(t, strings.Contains(stderr, "WARNING"), "零值输入应输出 WARNING")
-	assert.True(t, strings.Contains(stderr, "clamp"), "WARNING 应提示 clamp")
+	assert.Empty(t, stderr, "零值输入不应输出 warning")
 }
 
 func TestParseMaxRetries_NegativeInput(t *testing.T) {
 	stderr := captureStderr(t, func() {
 		result := parseMaxRetries("-1")
-		assert.Equal(t, 1, result, "负数输入应 clamp 到 1")
+		assert.Equal(t, 0, result, "负数输入应 clamp 到 0")
 	})
 	assert.True(t, strings.Contains(stderr, "WARNING"), "负数输入应输出 WARNING")
 	assert.True(t, strings.Contains(stderr, "clamp"), "WARNING 应提示 clamp")

--- a/automation/niuma/cmd/niuma/workflow_contract_test.go
+++ b/automation/niuma/cmd/niuma/workflow_contract_test.go
@@ -109,8 +109,10 @@ func TestWorkflowContract_ImplementGateUsesUnifiedCommand(t *testing.T) {
 
 	assert.Contains(t, content, "\"$NIUMA_BIN\" gate run")
 	assert.Contains(t, content, "MAX_RETRIES=2")
-	assert.Contains(t, content, "--max-retries \"$MAX_RETRIES\"")
+	assert.Contains(t, content, "--max-retries 0")
 	assert.Contains(t, content, "--self-check", "implement workflow 应使用 self-check 模式")
+	assert.Contains(t, content, "\"$NIUMA_BIN\" state-label set")
+	assert.Contains(t, content, "--to bot:pr-needs-fix")
 }
 
 func TestWorkflowContract_IterateGateUsesUnifiedCommand(t *testing.T) {

--- a/automation/niuma/go.mod
+++ b/automation/niuma/go.mod
@@ -1,6 +1,6 @@
 module github.com/biantaishabi2/Cli/automation/niuma
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/google/go-github/v68 v68.0.0

--- a/automation/niuma/go.sum
+++ b/automation/niuma/go.sum
@@ -3,6 +3,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v68 v68.0.0 h1:ZW57zeNZiXTdQ16qrDiZ0k6XucrxZ2CGmoTvcCyQG6s=
 github.com/google/go-github/v68 v68.0.0/go.mod h1:K9HAUBovM2sLwM408A18h+wd9vqdLOEqTUCbnRIcx68=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=

--- a/automation/niuma/pkg/gate/gate.go
+++ b/automation/niuma/pkg/gate/gate.go
@@ -142,6 +142,15 @@ func (r *Runner) Run(ctx context.Context) (Result, error) {
 		return result, fmt.Errorf("写入 gate retry_count 失败: %w", err)
 	}
 
+	addPRReview := func() {
+		if r.opts.AddPRReview != nil {
+			reviewBody := fmt.Sprintf("## ❌ Gate 测试失败详情\n\n```\n%s\n```\n\n- retry_count=%d\n- max_retries=%d\n- attempt_key=`%s`", gateFailure, retryCount, r.opts.MaxRetries, attemptKey)
+			if err := r.opts.AddPRReview(ctx, r.opts.Repo, r.opts.PR, reviewBody); err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: gate 失败信息写入 PR review 失败: %v\n", err)
+			}
+		}
+	}
+
 	if retryCount <= r.opts.MaxRetries {
 		if !r.opts.SelfCheck {
 			// 正常模式：设标签 + 写 issue 评论
@@ -154,12 +163,13 @@ func (r *Runner) Run(ctx context.Context) (Result, error) {
 			}
 		}
 		// 两种模式都写 PR review（失败详情供 iterate 读取）
-		if r.opts.AddPRReview != nil {
-			reviewBody := fmt.Sprintf("## ❌ Gate 测试失败详情\n\n```\n%s\n```\n\n- retry_count=%d\n- max_retries=%d\n- attempt_key=`%s`", gateFailure, retryCount, r.opts.MaxRetries, attemptKey)
-			if err := r.opts.AddPRReview(ctx, r.opts.Repo, r.opts.PR, reviewBody); err != nil {
-				fmt.Fprintf(os.Stderr, "WARNING: gate 失败信息写入 PR review 失败: %v\n", err)
-			}
-		}
+		addPRReview()
+		return result, fmt.Errorf("%w: %s", ErrGateFailed, gateFailure)
+	}
+
+	// self-check 模式下不做 escalate，只写 PR review 由外层流程决定后续动作。
+	if r.opts.SelfCheck {
+		addPRReview()
 		return result, fmt.Errorf("%w: %s", ErrGateFailed, gateFailure)
 	}
 

--- a/automation/niuma/pkg/gate/gate_test.go
+++ b/automation/niuma/pkg/gate/gate_test.go
@@ -471,8 +471,8 @@ func TestRunner_SelfCheck_SkipsMarkNeedsFixAndComment(t *testing.T) {
 	assert.Equal(t, 1, prReviewCalled, "self-check 模式仍应写 PR review")
 }
 
-func TestRunner_SelfCheck_EscalationStillWorks(t *testing.T) {
-	// self-check 模式下超限 escalation 行为不变
+func TestRunner_SelfCheck_OverLimitDoesNotEscalate(t *testing.T) {
+	// self-check 模式下即便超限也不做 issue 升级，交由外层 workflow 决策。
 	labelCalled := 0
 	commentCalled := 0
 
@@ -506,7 +506,7 @@ func TestRunner_SelfCheck_EscalationStillWorks(t *testing.T) {
 	result, err := runner.Run(context.Background())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrGateFailed)
-	assert.True(t, result.Escalated, "超限时 escalation 行为不变")
-	assert.Equal(t, 1, labelCalled, "超限时应打标签")
-	assert.Equal(t, 1, commentCalled, "超限时应写评论")
+	assert.False(t, result.Escalated, "self-check 模式超限不应直接 escalate")
+	assert.Equal(t, 0, labelCalled, "self-check 模式不应打标签")
+	assert.Equal(t, 0, commentCalled, "self-check 模式不应写 issue 评论")
 }


### PR DESCRIPTION
## Summary
- 修复 `self-check` 模式在超限时仍触发 escalation 的行为，改为：self-check 仅写 PR review，不打标/不写 issue 升级评论
- 修复 `--max-retries` 语义：允许 `0`（禁用自动重试），仅负数 clamp 到 `0`
- 调整 implement reusable workflow：
  - self-check 调用 `gate run --max-retries 0 --self-check`，避免内外层重试叠加
  - gate 失败后先 `state-label -> bot:pr-needs-fix` 再 `iterate`
- 更新契约测试与单元测试覆盖新语义

## Tests
- `go test ./pkg/gate`
- `go test ./cmd/niuma -run 'TestParseMaxRetries|TestWorkflowContract_ImplementGateUsesUnifiedCommand|TestWorkflowContract_IterateGateUsesUnifiedCommand|TestWorkflowContract_ReviewGateFailureTransitionsToNeedsFix'`

Closes #488
