### PR TITLE
fix: sync origin HEAD before default branch fallback

### DIFF
--- a/automation/niuma/pkg/agent/gitops.go
+++ b/automation/niuma/pkg/agent/gitops.go
@@ -224,10 +224,11 @@ func resolveDefaultBranch(workDir string) defaultBranchResolution {
 
 // resolveDefaultBranchWithExecutor 默认分支解析链路：
 // 1) symbolic-ref refs/remotes/origin/HEAD
-// 2) ls-remote --symref origin HEAD
-// 3) rev-parse --verify refs/remotes/origin/main
-// 4) remote show origin (HEAD branch)
-// 5) fallback master
+// 2) remote set-head origin -a 后重试 symbolic-ref
+// 3) ls-remote --symref origin HEAD
+// 4) rev-parse --verify refs/remotes/origin/main
+// 5) remote show origin (HEAD branch)
+// 6) fallback master
 func resolveDefaultBranchWithExecutor(workDir string, executor gitOutputExecutor, logf func(string, ...any)) defaultBranchResolution {
 	result := defaultBranchResolution{}
 
@@ -243,7 +244,23 @@ func resolveDefaultBranchWithExecutor(workDir string, executor gitOutputExecutor
 		appendProbeFailure(&result, "symbolic-ref", err, out, logf)
 	}
 
-	// 2) 远端 symref（标准输出）
+	// 2) CI 浅克隆等场景常缺失 origin/HEAD，先尝试同步后再读一次。
+	if out, err := executor.CombinedOutput(workDir, "remote", "set-head", "origin", "-a"); err == nil {
+		if retryOut, retryErr := executor.CombinedOutput(workDir, "symbolic-ref", "refs/remotes/origin/HEAD"); retryErr == nil {
+			if branch, ok := parseBranchFromRef(string(retryOut), "refs/remotes/origin/"); ok {
+				result.Branch = branch
+				result.Source = "symbolic-ref-after-set-head"
+				return result
+			}
+			appendProbeFailure(&result, "symbolic-ref(after set-head)", fmt.Errorf("输出无法解析为 refs/remotes/origin/<branch>"), retryOut, logf)
+		} else {
+			appendProbeFailure(&result, "symbolic-ref(after set-head)", retryErr, retryOut, logf)
+		}
+	} else {
+		appendProbeFailure(&result, "remote set-head origin -a", err, out, logf)
+	}
+
+	// 3) 远端 symref（标准输出）
 	if out, err := executor.CombinedOutput(workDir, "ls-remote", "--symref", "origin", "HEAD"); err == nil {
 		if branch, ok := parseBranchFromLSRemoteSymref(string(out)); ok {
 			result.Branch = branch
@@ -255,7 +272,7 @@ func resolveDefaultBranchWithExecutor(workDir string, executor gitOutputExecutor
 		appendProbeFailure(&result, "ls-remote --symref", err, out, logf)
 	}
 
-	// 3) 本地 origin/main 存在性探测
+	// 4) 本地 origin/main 存在性探测
 	if out, err := executor.CombinedOutput(workDir, "rev-parse", "--verify", "refs/remotes/origin/main"); err == nil {
 		result.Branch = "main"
 		result.Source = "local-origin-main"
@@ -264,7 +281,7 @@ func resolveDefaultBranchWithExecutor(workDir string, executor gitOutputExecutor
 		appendProbeFailure(&result, "rev-parse origin/main", err, out, logf)
 	}
 
-	// 4) remote show 文本兜底
+	// 5) remote show 文本兜底
 	if out, err := executor.CombinedOutput(workDir, "remote", "show", "origin"); err == nil {
 		if branch, ok := parseBranchFromRemoteShow(string(out)); ok {
 			result.Branch = branch
@@ -276,7 +293,7 @@ func resolveDefaultBranchWithExecutor(workDir string, executor gitOutputExecutor
 		appendProbeFailure(&result, "remote show origin", err, out, logf)
 	}
 
-	// 5) 最终兜底 master
+	// 6) 最终兜底 master
 	result.Branch = fallbackDefaultBranch
 	result.Source = "fallback-master"
 	result.UsedFallback = true

--- a/automation/niuma/pkg/agent/gitops_test.go
+++ b/automation/niuma/pkg/agent/gitops_test.go
@@ -157,13 +157,19 @@ type mockGitOutputResult struct {
 }
 
 type mockGitOutputExecutor struct {
-	results map[string]mockGitOutputResult
-	calls   []string
+	results   map[string]mockGitOutputResult
+	sequences map[string][]mockGitOutputResult
+	calls     []string
 }
 
 func (m *mockGitOutputExecutor) CombinedOutput(_ string, args ...string) ([]byte, error) {
 	key := strings.Join(args, " ")
 	m.calls = append(m.calls, key)
+	if seq, ok := m.sequences[key]; ok && len(seq) > 0 {
+		result := seq[0]
+		m.sequences[key] = seq[1:]
+		return []byte(result.out), result.err
+	}
 	if result, ok := m.results[key]; ok {
 		return []byte(result.out), result.err
 	}
@@ -174,6 +180,7 @@ func TestResolveDefaultBranchWithExecutor(t *testing.T) {
 	tests := []struct {
 		name           string
 		results        map[string]mockGitOutputResult
+		sequences      map[string][]mockGitOutputResult
 		expectedBranch string
 		expectedSource string
 		expectedCalls  []string
@@ -192,19 +199,41 @@ func TestResolveDefaultBranchWithExecutor(t *testing.T) {
 			name: "ls-remote symref fallback",
 			results: map[string]mockGitOutputResult{
 				"symbolic-ref refs/remotes/origin/HEAD": {err: fmt.Errorf("missing origin/HEAD")},
+				"remote set-head origin -a":             {err: fmt.Errorf("origin unavailable")},
 				"ls-remote --symref origin HEAD":        {out: "ref: refs/heads/develop\tHEAD\nabc\tHEAD\n"},
 			},
 			expectedBranch: "develop",
 			expectedSource: "ls-remote-symref",
 			expectedCalls: []string{
 				"symbolic-ref refs/remotes/origin/HEAD",
+				"remote set-head origin -a",
 				"ls-remote --symref origin HEAD",
+			},
+		},
+		{
+			name: "set-head sync fallback",
+			results: map[string]mockGitOutputResult{
+				"remote set-head origin -a": {out: "origin/HEAD set to main\n"},
+			},
+			sequences: map[string][]mockGitOutputResult{
+				"symbolic-ref refs/remotes/origin/HEAD": {
+					{err: fmt.Errorf("missing origin/HEAD")},
+					{out: "refs/remotes/origin/main\n"},
+				},
+			},
+			expectedBranch: "main",
+			expectedSource: "symbolic-ref-after-set-head",
+			expectedCalls: []string{
+				"symbolic-ref refs/remotes/origin/HEAD",
+				"remote set-head origin -a",
+				"symbolic-ref refs/remotes/origin/HEAD",
 			},
 		},
 		{
 			name: "local origin/main fallback",
 			results: map[string]mockGitOutputResult{
 				"symbolic-ref refs/remotes/origin/HEAD": {err: fmt.Errorf("missing origin/HEAD")},
+				"remote set-head origin -a":             {err: fmt.Errorf("origin unavailable")},
 				"ls-remote --symref origin HEAD":        {err: fmt.Errorf("origin unavailable")},
 				"rev-parse --verify refs/remotes/origin/main": {
 					out: "0123456789abcdef\n",
@@ -214,6 +243,7 @@ func TestResolveDefaultBranchWithExecutor(t *testing.T) {
 			expectedSource: "local-origin-main",
 			expectedCalls: []string{
 				"symbolic-ref refs/remotes/origin/HEAD",
+				"remote set-head origin -a",
 				"ls-remote --symref origin HEAD",
 				"rev-parse --verify refs/remotes/origin/main",
 			},
@@ -222,6 +252,7 @@ func TestResolveDefaultBranchWithExecutor(t *testing.T) {
 			name: "remote show fallback",
 			results: map[string]mockGitOutputResult{
 				"symbolic-ref refs/remotes/origin/HEAD":       {err: fmt.Errorf("missing origin/HEAD")},
+				"remote set-head origin -a":                   {err: fmt.Errorf("origin unavailable")},
 				"ls-remote --symref origin HEAD":              {err: fmt.Errorf("origin unavailable")},
 				"rev-parse --verify refs/remotes/origin/main": {err: fmt.Errorf("no origin/main")},
 				"remote show origin":                          {out: "  HEAD branch: release/v2\n"},
@@ -230,6 +261,7 @@ func TestResolveDefaultBranchWithExecutor(t *testing.T) {
 			expectedSource: "remote-show",
 			expectedCalls: []string{
 				"symbolic-ref refs/remotes/origin/HEAD",
+				"remote set-head origin -a",
 				"ls-remote --symref origin HEAD",
 				"rev-parse --verify refs/remotes/origin/main",
 				"remote show origin",
@@ -239,6 +271,7 @@ func TestResolveDefaultBranchWithExecutor(t *testing.T) {
 			name: "fallback master when all probes fail",
 			results: map[string]mockGitOutputResult{
 				"symbolic-ref refs/remotes/origin/HEAD":       {err: fmt.Errorf("missing origin/HEAD")},
+				"remote set-head origin -a":                   {err: fmt.Errorf("origin unavailable")},
 				"ls-remote --symref origin HEAD":              {err: fmt.Errorf("origin unavailable")},
 				"rev-parse --verify refs/remotes/origin/main": {err: fmt.Errorf("no origin/main")},
 				"remote show origin":                          {err: fmt.Errorf("origin unavailable")},
@@ -248,6 +281,7 @@ func TestResolveDefaultBranchWithExecutor(t *testing.T) {
 			usedFallback:   true,
 			expectedCalls: []string{
 				"symbolic-ref refs/remotes/origin/HEAD",
+				"remote set-head origin -a",
 				"ls-remote --symref origin HEAD",
 				"rev-parse --verify refs/remotes/origin/main",
 				"remote show origin",
@@ -257,7 +291,10 @@ func TestResolveDefaultBranchWithExecutor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			executor := &mockGitOutputExecutor{results: tt.results}
+			executor := &mockGitOutputExecutor{
+				results:   tt.results,
+				sequences: tt.sequences,
+			}
 			result := resolveDefaultBranchWithExecutor(t.TempDir(), executor, nil)
 
 			assert.Equal(t, tt.expectedBranch, result.Branch)
@@ -272,6 +309,7 @@ func TestResolveDefaultBranchWithExecutor_StrictParsing(t *testing.T) {
 	executor := &mockGitOutputExecutor{
 		results: map[string]mockGitOutputResult{
 			"symbolic-ref refs/remotes/origin/HEAD":       {out: "origin/main\n"},
+			"remote set-head origin -a":                   {out: "origin/HEAD set to main\n"},
 			"ls-remote --symref origin HEAD":              {out: "ref: refs/heads/feature/x\tHEAD\n"},
 			"rev-parse --verify refs/remotes/origin/main": {err: fmt.Errorf("should not reach")},
 			"remote show origin":                          {err: fmt.Errorf("should not reach")},
@@ -281,5 +319,5 @@ func TestResolveDefaultBranchWithExecutor_StrictParsing(t *testing.T) {
 	result := resolveDefaultBranchWithExecutor(t.TempDir(), executor, nil)
 	assert.Equal(t, "feature/x", result.Branch)
 	assert.Equal(t, "ls-remote-symref", result.Source)
-	assert.Len(t, result.ProbeFailures, 1)
+	assert.Len(t, result.ProbeFailures, 2)
 }


### PR DESCRIPTION
Summary
- 在 #484 的默认分支探测链路中新增 `git remote set-head origin -a` 自愈步骤。
- 仅在首次 `symbolic-ref refs/remotes/origin/HEAD` 失败后触发，并在同步后重试一次 symbolic-ref。
- 保留 #484 原有 fallback 顺序（ls-remote / origin-main / remote show / master）不变。

Test plan
- `cd automation/niuma && go test -mod=mod ./pkg/agent -count=1`
- 覆盖新增用例：set-head 成功后重试 symbolic-ref 命中默认分支。
- 覆盖原有用例：ls-remote、origin/main、remote show、fallback master 路径仍通过。
