### PR TITLE
fix: closed issue 收口 done/辅助标签归一化 (#504)

### DIFF
--- a/automation/niuma/go.mod
+++ b/automation/niuma/go.mod
@@ -1,6 +1,6 @@
 module github.com/biantaishabi2/Cli/automation/niuma
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/google/go-github/v68 v68.0.0

--- a/automation/niuma/pkg/control/controller.go
+++ b/automation/niuma/pkg/control/controller.go
@@ -866,7 +866,7 @@ func (c *Controller) Run(ctx context.Context) error {
 	pruneTasks, err := c.taskctl.List("")
 	if err != nil {
 		fmt.Printf("[control][prune] 读取 task 列表失败，跳过裁剪: %v\n", err)
-	} else if pruned := c.pruneClosedIssueTasks(allIssuesCache, pruneTasks); pruned > 0 {
+	} else if pruned := c.pruneClosedIssueTasks(ctx, allIssuesCache, pruneTasks); pruned > 0 {
 		fmt.Printf("[control][prune] 本轮共裁剪 %d 个已关闭 issue 的 task\n", pruned)
 	}
 
@@ -1801,18 +1801,52 @@ func (c *Controller) logPRReviewableDecision(
 	)
 }
 
-// pruneClosedIssueTasks 裁剪已关闭 issue 对应的 active task，标记为 completed。
+// pruneClosedIssueTasks 处理已关闭 issue 的收口：
+// 1) 将关闭但仍处于非 done 的 bot 状态收敛到 bot:done；
+// 2) 清理 needs-human / integration-* 辅助标签；
+// 3) 裁剪已关闭 issue 对应的 active task，标记为 completed。
 // 返回被裁剪的 task 数量。
-func (c *Controller) pruneClosedIssueTasks(allIssues []IssueInfo, existingTasks []Task) int {
+func (c *Controller) pruneClosedIssueTasks(ctx context.Context, allIssues []IssueInfo, existingTasks []Task) int {
 	// 构建 closed issue 集合
-	closedIssues := make(map[int]bool, len(allIssues))
+	closedIssues := make(map[int]IssueInfo, len(allIssues))
 	for _, issue := range allIssues {
 		if strings.EqualFold(issue.State, "closed") {
-			closedIssues[issue.Number] = true
+			closedIssues[issue.Number] = issue
 		}
 	}
 	if len(closedIssues) == 0 {
 		return 0
+	}
+
+	// closed issue 标签收口：与 task 活跃状态无关，避免“已关闭但仍 needs-human”残留。
+	for issueNum, issue := range closedIssues {
+		labels := issue.Labels
+		hasAux := hasLabel(labels, needsHumanLabel) ||
+			hasLabel(labels, integrationConflictLabel) ||
+			hasLabel(labels, integrationGateFailLabel)
+
+		// 仅当存在非 done bot 状态时迁移，避免给无状态 issue 额外打 bot:done。
+		needsDone := false
+		if botStates, invalid := state.CollectBotStatesWithInvalid(labels); len(invalid) > 0 {
+			fmt.Printf("[control][prune] issue #%d 存在非法 bot 标签，跳过 done 收口: %v\n", issueNum, invalid)
+		} else if len(botStates) > 0 {
+			if len(botStates) > 1 || botStates[0] != state.StateDone {
+				needsDone = true
+			}
+		}
+
+		if !needsDone && !hasAux {
+			continue
+		}
+
+		if needsDone {
+			if err := c.syncIssueStateLabel(ctx, issueNum, botDoneLabel); err != nil {
+				fmt.Printf("[control][prune] issue #%d 收敛到 %s 失败: %v\n", issueNum, botDoneLabel, err)
+			}
+		}
+		if err := c.normalizeDoneAuxLabels(ctx, issueNum); err != nil {
+			fmt.Printf("[control][prune] issue #%d 清理关闭态辅助标签失败: %v\n", issueNum, err)
+		}
 	}
 
 	pruned := 0
@@ -1821,7 +1855,7 @@ func (c *Controller) pruneClosedIssueTasks(allIssues []IssueInfo, existingTasks 
 		if issueNum == 0 {
 			continue
 		}
-		if !closedIssues[issueNum] {
+		if _, ok := closedIssues[issueNum]; !ok {
 			continue
 		}
 		if !isTaskActiveStatus(task.Status) {

--- a/automation/niuma/pkg/control/controller_test.go
+++ b/automation/niuma/pkg/control/controller_test.go
@@ -4623,3 +4623,59 @@ func TestPruneClosedIssueTasks_no_closed(t *testing.T) {
 	assert.Equal(t, TaskStatusPending, ctrl.mockTaskCtl.tasks[0].Status)
 	assert.Equal(t, TaskStatusInProgress, ctrl.mockTaskCtl.tasks[1].Status)
 }
+
+func TestPruneClosedIssueTasks_NormalizeClosedIssueLabelsWithoutTask(t *testing.T) {
+	mockGH := newMockGitHubOps(
+		IssueInfo{
+			Number: 502,
+			Title:  "closed issue",
+			State:  "closed",
+			Labels: []string{"bot:pr-needs-fix", needsHumanLabel, integrationGateFailLabel},
+		},
+	)
+	ctrl := &Controller{github: mockGH}
+
+	allIssues, err := mockGH.ListIssuesByState(context.Background(), "all")
+	require.NoError(t, err)
+
+	pruned := ctrl.pruneClosedIssueTasks(context.Background(), allIssues, nil)
+	assert.Equal(t, 0, pruned, "无 active task 时不应统计裁剪数量")
+
+	labels, err := mockGH.ListLabels(context.Background(), 502)
+	require.NoError(t, err)
+	assert.Contains(t, labels, botDoneLabel)
+	assert.NotContains(t, labels, "bot:pr-needs-fix")
+	assert.NotContains(t, labels, needsHumanLabel)
+	assert.NotContains(t, labels, integrationGateFailLabel)
+}
+
+func TestPruneClosedIssueTasks_NormalizeClosedIssueLabelsIdempotent(t *testing.T) {
+	mockGH := newMockGitHubOps(
+		IssueInfo{
+			Number: 503,
+			Title:  "closed issue",
+			State:  "closed",
+			Labels: []string{"bot:pr-needs-fix", needsHumanLabel, integrationConflictLabel, integrationGateFailLabel},
+		},
+	)
+	ctrl := &Controller{github: mockGH}
+
+	allIssues, err := mockGH.ListIssuesByState(context.Background(), "all")
+	require.NoError(t, err)
+
+	ctrl.pruneClosedIssueTasks(context.Background(), allIssues, nil)
+	firstLabels, err := mockGH.ListLabels(context.Background(), 503)
+	require.NoError(t, err)
+
+	allIssues, err = mockGH.ListIssuesByState(context.Background(), "all")
+	require.NoError(t, err)
+	ctrl.pruneClosedIssueTasks(context.Background(), allIssues, nil)
+	secondLabels, err := mockGH.ListLabels(context.Background(), 503)
+	require.NoError(t, err)
+
+	assert.Equal(t, firstLabels, secondLabels, "重复执行应保持标签集合稳定")
+	assert.Equal(t, 1, countLabel(secondLabels, botDoneLabel), "bot:done 不应重复")
+	assert.NotContains(t, secondLabels, needsHumanLabel)
+	assert.NotContains(t, secondLabels, integrationConflictLabel)
+	assert.NotContains(t, secondLabels, integrationGateFailLabel)
+}


### PR DESCRIPTION
## Summary
- 在 `pruneClosedIssueTasks` 增加 closed issue 的统一收口：
  - closed 且仍是非 done `bot:*` 时，迁移到 `bot:done`
  - 清理 `needs-human` / `integration-conflict` / `integration-gate-failed`
- 收口逻辑不再依赖 task 是否活跃，避免“已关闭 issue 仍残留升级标签”
- 新增单测覆盖无 task 收口与幂等

## Test plan
- `cd automation/niuma && /usr/local/go.bak/bin/go test ./pkg/control -run 'TestPruneClosedIssueTasks_(basic|already_completed|no_closed|NormalizeClosedIssueLabelsWithoutTask|NormalizeClosedIssueLabelsIdempotent)|TestFinalizeIntegratedIssues_ClosedIssueIsIdempotent|TestReconcileNeedsHumanRecovery_GateRecovered' -count=1 -v`
- `cd automation/niuma && /usr/local/go.bak/bin/go test ./cmd/niuma -run 'TestResolveIntegrationGateMaxRetries|TestResolvePRConflictRetryThreshold|TestResolvePRConflictUnknownBackoffs' -count=1 -v`

Closes #504
