### PR TITLE
fix(niuma): avoid gate deferred loops and head-scoped retry key (#511)

### DIFF
--- a/.github/workflows/niuma-review-reusable.yml
+++ b/.github/workflows/niuma-review-reusable.yml
@@ -135,14 +135,29 @@ jobs:
           echo "run_mode=${{ steps.pr_gate.outputs.run_mode }}"
           echo "risk_level=${{ steps.pr_gate.outputs.risk_level }}"
           echo "required_jobs=${{ steps.pr_gate.outputs.required_jobs }}"
+          echo "reason_code=${{ steps.pr_gate.outputs.reason_code }}"
 
       - name: Restore Workspace After Gate
         if: steps.find_pr.outputs.pr_number != '' && steps.pr_gate.outcome == 'success'
         run: |
           git checkout --force "$GITHUB_SHA"
 
-      - name: Gate Failed -> Transition to PR Needs Fix
+      - name: Decide Gate Failure Action
+        id: gate_failure_action
         if: steps.find_pr.outputs.pr_number != '' && steps.pr_gate.outcome == 'failure'
+        env:
+          REASON_CODE: ${{ steps.pr_gate.outputs.reason_code }}
+        run: |
+          reason="${REASON_CODE:-UNKNOWN}"
+          action="defer"
+          if [ "$reason" = "REQUIRED_JOBS_FAILED" ]; then
+            action="needs_fix"
+          fi
+          echo "action=$action" >> "$GITHUB_OUTPUT"
+          echo "reason_code=$reason" >> "$GITHUB_OUTPUT"
+
+      - name: Gate Failed (Code) -> Transition to PR Needs Fix
+        if: steps.find_pr.outputs.pr_number != '' && steps.pr_gate.outcome == 'failure' && steps.gate_failure_action.outputs.action == 'needs_fix'
         env:
           GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
           REPO: ${{ inputs.repo }}
@@ -153,6 +168,19 @@ jobs:
             --issue "$ISSUE_NUMBER" \
             --from bot:pr-created \
             --to bot:pr-needs-fix
+
+      - name: Gate Deferred -> Keep PR Created
+        if: steps.find_pr.outputs.pr_number != '' && steps.pr_gate.outcome == 'failure' && steps.gate_failure_action.outputs.action == 'defer'
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          REPO: ${{ inputs.repo }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          REASON_CODE: ${{ steps.gate_failure_action.outputs.reason_code }}
+        run: |
+          reason="${REASON_CODE:-UNKNOWN}"
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --body "## ⏳ Gate 未决，暂不触发迭代\n\n- reason_code=\`$reason\`\n\n本轮未检测到明确代码失败，保持 \`bot:pr-created\`，避免无效 \`bot:pr-needs-fix -> iterate\` 循环。"
 
       - name: AI Self-Review
         if: steps.find_pr.outputs.pr_number != '' && steps.pr_gate.outcome == 'success'

--- a/automation/niuma/cmd/niuma/gate_run.go
+++ b/automation/niuma/cmd/niuma/gate_run.go
@@ -170,9 +170,11 @@ func runGateRun(cmd *cobra.Command, args []string) error {
 	if errors.Is(err, gate.ErrGateFailed) {
 		displayRetryCount := retryCountForDisplay(result.RetryCount, result.AttemptKey)
 		fmt.Printf(
-			"gate 未通过: issue=%d pr=%d retry_count=%d max_retries=%d attempt_key=%s escalated=%t dedup=%t\n",
+			"gate 未通过: issue=%d pr=%d reason_code=%s failure_class=%s retry_count=%d max_retries=%d attempt_key=%s escalated=%t dedup=%t\n",
 			flagIssue,
 			flagPR,
+			result.ReasonCode,
+			result.FailureClass,
 			displayRetryCount,
 			result.MaxRetries,
 			result.AttemptKey,

--- a/automation/niuma/cmd/niuma/workflow_contract_test.go
+++ b/automation/niuma/cmd/niuma/workflow_contract_test.go
@@ -155,7 +155,7 @@ func TestWorkflowContract_IterateGateUsesUnifiedCommand(t *testing.T) {
 	assert.Equal(t, 2, strings.Count(content, "--max-retries \"$GATE_MAX_RETRIES\""))
 }
 
-func TestWorkflowContract_ReviewGateFailureTransitionsToNeedsFix(t *testing.T) {
+func TestWorkflowContract_ReviewGateFailureUsesReasonCodeRouting(t *testing.T) {
 	content := loadWorkflowFile(t, "niuma-review-reusable.yml")
 
 	assert.Contains(t, content, "id: pr_gate")
@@ -163,9 +163,15 @@ func TestWorkflowContract_ReviewGateFailureTransitionsToNeedsFix(t *testing.T) {
 	assert.Contains(t, content, "Restore Workspace After Gate")
 	assert.Contains(t, content, "git checkout --force \"$GITHUB_SHA\"")
 	assert.Contains(t, content, "steps.pr_gate.outcome == 'failure'")
+	assert.Contains(t, content, "Decide Gate Failure Action")
+	assert.Contains(t, content, "reason_code")
+	assert.Contains(t, content, "REQUIRED_JOBS_FAILED")
+	assert.Contains(t, content, "action == 'needs_fix'")
 	assert.Contains(t, content, "\"$NIUMA_BIN\" state-label set")
 	assert.Contains(t, content, "--from bot:pr-created")
 	assert.Contains(t, content, "--to bot:pr-needs-fix")
+	assert.Contains(t, content, "Gate Deferred -> Keep PR Created")
+	assert.Contains(t, content, "action == 'defer'")
 	assert.Contains(t, content, "steps.pr_gate.outcome == 'success'")
 	assert.NotContains(t, content, "skip_test_gate")
 }

--- a/automation/niuma/pkg/gate/gate.go
+++ b/automation/niuma/pkg/gate/gate.go
@@ -18,10 +18,18 @@ const (
 	integrationGateFailedLabel      = "integration-gate-failed" // 瞬时失败辅助标签：仅表达“当前 gate 阻塞”，恢复后由 control 归一化清理
 	defaultGateScriptRelativePath   = ".github/scripts/niuma-test-gate.sh"
 	defaultNeedsFixCommentTemplate  = "## ❌ Gate 未通过\n\n自动测试门禁失败，已回退为 `bot:pr-needs-fix`，请继续迭代修复。\n\n- retry_count=%d\n- max_retries=%d\n- attempt_key=`%s`"
+	defaultDeferredCommentTemplate  = "## ⏳ Gate 暂未形成代码失败结论\n\n本轮 gate 失败原因为 `%s`（通常是 checks 未就绪或查询异常），已保留当前状态，不回退 `bot:pr-needs-fix`，避免无效 iterate 循环。\n\n- attempt_key=`%s`"
 	defaultEscalatedCommentTemplate = "## 🚨 Gate 已超限，升级人工处理\n\nintegration gate 失败次数已超过上限，本轮不再触发自动修复。\n\n- retry_count=%d\n- max_retries=%d\n- attempt_key=`%s`"
 )
 
 var ErrGateFailed = errors.New("gate failed")
+
+type FailureClass string
+
+const (
+	FailureClassCode     FailureClass = "code_failure"
+	FailureClassDeferred FailureClass = "deferred"
+)
 
 type RunGateFunc func(ctx context.Context, repoDir string, pr int) (string, error)
 type MarkNeedsFixFunc func(ctx context.Context, repo string, issue int) error
@@ -62,6 +70,8 @@ type Result struct {
 	RetryCount               int
 	MaxRetries               int
 	AttemptKey               string
+	ReasonCode               string
+	FailureClass             FailureClass
 	Escalated                bool
 	EscalationCommentSkipped bool
 }
@@ -116,15 +126,45 @@ func (r *Runner) Run(ctx context.Context) (Result, error) {
 	if gateErr == nil {
 		// gate 通过，重置计数
 		result.Passed = true
+		result.ReasonCode = "PASS"
 		if err := r.opts.UpsertGateRetryCount(ctx, r.opts.Issue, 0, ""); err != nil {
 			return result, fmt.Errorf("gate 通过后重置 retry_count 失败: %w", err)
 		}
 		return result, nil
 	}
 
-	attemptKey := buildAttemptKey(r.opts.Issue, r.opts.PR, r.opts.Now(), r.opts.RunID, r.opts.RunAttempt)
+	reasonCode := normalizeReasonCode(extractGateField(gateOutput, "reason_code"))
+	if reasonCode == "" {
+		reasonCode = "UNKNOWN"
+	}
+	result.ReasonCode = reasonCode
+	result.FailureClass = classifyFailureReason(reasonCode)
+
+	headSHA := extractGateField(gateOutput, "head_sha")
+	attemptKey := buildAttemptKey(r.opts.Issue, r.opts.PR, r.opts.Now(), r.opts.RunID, r.opts.RunAttempt, headSHA)
 	result.AttemptKey = attemptKey
 	gateFailure := trimGateError(gateOutput, gateErr)
+
+	// checks 未就绪/查询异常等未决失败，不应触发 pr-needs-fix 循环。
+	if result.FailureClass == FailureClassDeferred {
+		result.RetryCount = 0
+		if err := r.opts.UpsertGateRetryCount(ctx, r.opts.Issue, 0, ""); err != nil {
+			return result, fmt.Errorf("gate 未决场景重置 retry_count 失败: %w", err)
+		}
+		if !r.opts.SelfCheck {
+			commentBody := fmt.Sprintf(defaultDeferredCommentTemplate, result.ReasonCode, attemptKey)
+			if err := r.opts.AddComment(ctx, r.opts.Repo, r.opts.Issue, commentBody); err != nil {
+				return result, fmt.Errorf("%w: gate 未决评论发布失败: %v", ErrGateFailed, err)
+			}
+		}
+		if r.opts.AddPRReview != nil {
+			reviewBody := fmt.Sprintf("## ⏳ Gate 暂未形成代码失败结论\n\n```\n%s\n```\n\n- reason_code=%s\n- attempt_key=`%s`", gateFailure, result.ReasonCode, attemptKey)
+			if err := r.opts.AddPRReview(ctx, r.opts.Repo, r.opts.PR, reviewBody); err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: gate 未决信息写入 PR review 失败: %v\n", err)
+			}
+		}
+		return result, fmt.Errorf("%w: gate deferred (%s): %s", ErrGateFailed, result.ReasonCode, gateFailure)
+	}
 
 	// 从 marker 读取上次 retry_count（仅同 attempt_key 延续；否则从 0 开始）
 	prevCount, prevAttemptKey, err := r.opts.FindGateRetryState(ctx, r.opts.Issue)
@@ -199,7 +239,10 @@ func runGateScript(ctx context.Context, repoDir string, pr int) (string, error) 
 	return strings.TrimSpace(string(out)), err
 }
 
-func buildAttemptKey(issue, pr int, now time.Time, runID, runAttempt string) string {
+func buildAttemptKey(issue, pr int, now time.Time, runID, runAttempt, headSHA string) string {
+	if sanitizedHead := sanitizeHeadSHA(headSHA); sanitizedHead != "" {
+		return fmt.Sprintf("issue-%d-pr-%d-head-%s", issue, pr, sanitizedHead)
+	}
 	if strings.TrimSpace(runID) != "" {
 		attempt := strings.TrimSpace(runAttempt)
 		if attempt == "" {
@@ -233,4 +276,53 @@ func trimGateError(output string, runErr error) string {
 		return joined
 	}
 	return joined[:maxGateErrorMessageLen]
+}
+
+func classifyFailureReason(reasonCode string) FailureClass {
+	switch normalizeReasonCode(reasonCode) {
+	case
+		"CHECKS_QUERY_FAILED",
+		"REQUIRED_JOBS_PENDING",
+		"PENDING_RETRYING",
+		"PENDING_BLOCKED",
+		"REQUIRED_JOBS_MISSING",
+		"CRITICAL_REGRESSION_MISSING",
+		"INSUFFICIENT_COVERAGE_FOR_HIGH_RISK",
+		"REQUIRED_JOBS_NOT_EXECUTED",
+		"REQUIRED_JOBS_TIMEOUT",
+		"TIMEOUT_RETRYING",
+		"TIMEOUT_BLOCKED":
+		return FailureClassDeferred
+	default:
+		return FailureClassCode
+	}
+}
+
+func normalizeReasonCode(raw string) string {
+	return strings.ToUpper(strings.TrimSpace(raw))
+}
+
+func extractGateField(output, key string) string {
+	wantPrefix := key + "="
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "[gate] ")
+		if line == "" {
+			continue
+		}
+		for _, token := range strings.Fields(line) {
+			if strings.HasPrefix(token, wantPrefix) {
+				return strings.TrimSpace(strings.TrimPrefix(token, wantPrefix))
+			}
+		}
+	}
+	return ""
+}
+
+func sanitizeHeadSHA(raw string) string {
+	head := strings.ToLower(strings.TrimSpace(raw))
+	if head == "" || head == "unknown" {
+		return ""
+	}
+	return head
 }

--- a/automation/niuma/pkg/gate/gate_test.go
+++ b/automation/niuma/pkg/gate/gate_test.go
@@ -108,6 +108,8 @@ func TestRunner_FirstFailureMarksNeedsFix(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrGateFailed)
 	assert.False(t, result.Passed)
+	assert.Equal(t, "UNKNOWN", result.ReasonCode)
+	assert.Equal(t, FailureClassCode, result.FailureClass)
 	assert.False(t, result.Escalated)
 	assert.Equal(t, defaultAttemptKey(358, 9010), result.AttemptKey)
 	assert.Equal(t, 1, result.RetryCount)
@@ -119,6 +121,75 @@ func TestRunner_FirstFailureMarksNeedsFix(t *testing.T) {
 	assert.Contains(t, comments[0], "retry_count=1")
 	assert.Contains(t, comments[0], "max_retries=2")
 	assert.Contains(t, comments[0], defaultAttemptKey(358, 9010))
+}
+
+func TestRunner_DeferredFailureSkipsNeedsFix(t *testing.T) {
+	markCalled := 0
+	labelCalled := 0
+	issueComments := make([]string, 0, 1)
+	prReviews := make([]string, 0, 1)
+	upsertCalls := make([]struct {
+		count      int
+		attemptKey string
+	}, 0, 1)
+
+	runner := newRunnerForTest(t, Options{
+		Repo:       "biantaishabi2/Cli",
+		Issue:      358,
+		PR:         9015,
+		RepoDir:    t.TempDir(),
+		MaxRetries: 2,
+		Now:        fixedNow,
+		RunGate: func(context.Context, string, int) (string, error) {
+			return "[gate] reason_code=CHECKS_QUERY_FAILED\n[gate] head_sha=abc123\n[gate][warning] 查询 PR checks 失败", errors.New("exit status 1")
+		},
+		MarkNeedsFix: func(context.Context, string, int) error {
+			markCalled++
+			return nil
+		},
+		AddLabels: func(context.Context, string, int, []string) error {
+			labelCalled++
+			return nil
+		},
+		AddComment: func(_ context.Context, _ string, _ int, body string) error {
+			issueComments = append(issueComments, body)
+			return nil
+		},
+		FindGateRetryState: func(context.Context, int) (int, string, error) {
+			return 1, "issue-358-pr-9015-head-abc123", nil
+		},
+		UpsertGateRetryCount: func(_ context.Context, _ int, count int, attemptKey string) error {
+			upsertCalls = append(upsertCalls, struct {
+				count      int
+				attemptKey string
+			}{count: count, attemptKey: attemptKey})
+			return nil
+		},
+		HasLabel: func(context.Context, int, string) (bool, error) { return false, nil },
+		AddPRReview: func(_ context.Context, _ string, _ int, body string) error {
+			prReviews = append(prReviews, body)
+			return nil
+		},
+	})
+
+	result, err := runner.Run(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGateFailed)
+	assert.False(t, result.Passed)
+	assert.Equal(t, "CHECKS_QUERY_FAILED", result.ReasonCode)
+	assert.Equal(t, FailureClassDeferred, result.FailureClass)
+	assert.Equal(t, "issue-358-pr-9015-head-abc123", result.AttemptKey)
+	assert.Equal(t, 0, result.RetryCount, "deferred 场景不应进入自动修复计数")
+	assert.Equal(t, 0, markCalled, "deferred 场景不应回退到 pr-needs-fix")
+	assert.Equal(t, 0, labelCalled, "deferred 场景不应升级标签")
+	require.Len(t, issueComments, 1)
+	assert.Contains(t, issueComments[0], "Gate 暂未形成代码失败结论")
+	assert.Contains(t, issueComments[0], "CHECKS_QUERY_FAILED")
+	require.Len(t, prReviews, 1)
+	assert.Contains(t, prReviews[0], "reason_code=CHECKS_QUERY_FAILED")
+	require.Len(t, upsertCalls, 1)
+	assert.Equal(t, 0, upsertCalls[0].count)
+	assert.Equal(t, "", upsertCalls[0].attemptKey)
 }
 
 func TestRunner_SameRunRetryCountAccumulates(t *testing.T) {
@@ -153,6 +224,47 @@ func TestRunner_SameRunRetryCountAccumulates(t *testing.T) {
 	assert.Equal(t, 2, result.RetryCount, "同 run 内 retry_count 应为 1+1=2")
 	assert.Equal(t, 2, upsertedCount)
 	assert.False(t, result.Escalated, "retry_count=2 == maxRetries=2，不应 escalate")
+}
+
+func TestRunner_HeadScopedAttemptKeyAccumulatesAcrossRuns(t *testing.T) {
+	var upsertedCount int
+	var upsertedAttemptKey string
+
+	runner := newRunnerForTest(t, Options{
+		Repo:       "biantaishabi2/Cli",
+		Issue:      358,
+		PR:         9020,
+		RepoDir:    t.TempDir(),
+		MaxRetries: 5,
+		Now:        fixedNow,
+		RunID:      "new-run-id",
+		RunAttempt: "9",
+		RunGate: func(context.Context, string, int) (string, error) {
+			return "[gate] reason_code=REQUIRED_JOBS_FAILED\n[gate] head_sha=abc999\n[gate] run_mode=critical", errors.New("exit status 1")
+		},
+		MarkNeedsFix: func(context.Context, string, int) error { return nil },
+		AddLabels:    func(context.Context, string, int, []string) error { return nil },
+		AddComment:   func(context.Context, string, int, string) error { return nil },
+		FindGateRetryState: func(context.Context, int) (int, string, error) {
+			return 2, "issue-358-pr-9020-head-abc999", nil
+		},
+		UpsertGateRetryCount: func(_ context.Context, _ int, count int, attemptKey string) error {
+			upsertedCount = count
+			upsertedAttemptKey = attemptKey
+			return nil
+		},
+		HasLabel: func(context.Context, int, string) (bool, error) { return false, nil },
+	})
+
+	result, err := runner.Run(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGateFailed)
+	assert.Equal(t, FailureClassCode, result.FailureClass)
+	assert.Equal(t, "REQUIRED_JOBS_FAILED", result.ReasonCode)
+	assert.Equal(t, "issue-358-pr-9020-head-abc999", result.AttemptKey)
+	assert.Equal(t, 3, result.RetryCount, "同一 head 跨 run 应继续累计")
+	assert.Equal(t, 3, upsertedCount)
+	assert.Equal(t, "issue-358-pr-9020-head-abc999", upsertedAttemptKey)
 }
 
 func TestRunner_CrossRunRetryCountResets(t *testing.T) {


### PR DESCRIPTION
## Summary
- classify gate failures by `reason_code` in `gate.Runner` and only route `REQUIRED_JOBS_FAILED` to auto-fix path
- treat deferred reasons (`CHECKS_QUERY_FAILED`/pending/missing/timeout family) as non-code failures: keep current state and post deferred message instead of bouncing to `bot:pr-needs-fix`
- make `attempt_key` head-scoped (`issue-pr-head_sha`) when available, so retry state does not reset every workflow run
- update `niuma-review-reusable.yml` to route gate failure actions by `reason_code` (`needs_fix` vs `defer`)
- extend gate + workflow contract tests and expose `reason_code`/`failure_class` in `niuma gate run` output

## Test plan
- `cd automation/niuma && go test ./pkg/gate ./cmd/niuma`

Closes #511
