### PR TITLE
sub(#517): CLI --go-module and .bddc.toml Go target support

### DIFF
--- a/compiler/bddc/lib/bdd_compiler/cli.ex
+++ b/compiler/bddc/lib/bdd_compiler/cli.ex
@@ -115,13 +115,30 @@ defmodule BDDCompiler.CLI do
 
     target = parse_target(Keyword.get(opts, :target, "elixir"))
 
+    # 对于 Go target，--go-module 优先，否则回退到 --module-prefix
+    module_prefix =
+      if target == :go do
+        go_mod = Keyword.get(opts, :go_module)
+        fallback = Keyword.get(opts, :module_prefix)
+
+        cond do
+          is_binary(go_mod) and go_mod != "" -> go_mod
+          is_binary(fallback) and fallback != "" -> fallback
+          true ->
+            IO.puts(:stderr, "[warn] --target go 未指定 --go-module，将使用 GoEmitter 默认值")
+            nil
+        end
+      else
+        Keyword.get(opts, :module_prefix, "BDD.Generated")
+      end
+
     compile_opts =
       [
         docs_root: docs_root,
         target: target,
         runtime_module: Keyword.get(opts, :runtime_module, "BDD.Instructions.V1"),
         test_case: Keyword.get(opts, :test_case, "ExUnit.Case"),
-        module_prefix: Keyword.get(opts, :module_prefix, "BDD.Generated")
+        module_prefix: module_prefix
       ]
       |> Enum.reject(fn {_k, v} -> is_nil(v) end)
 
@@ -671,6 +688,8 @@ defmodule BDDCompiler.CLI do
     |> maybe_put_from_cfg(cfg, section, :out, "out")
     |> maybe_put_from_cfg(cfg, section, :test_case, "test_case")
     |> maybe_put_from_cfg(cfg, section, :module_prefix, "module_prefix")
+    |> maybe_put_from_cfg(cfg, section, :target, "target")
+    |> maybe_put_from_cfg(cfg, section, :go_module, "go_module")
     |> maybe_put_runtime_sources_from_cfg(cfg, section, project_root)
     |> maybe_put_instructions_from_cfg(cfg, section, project_root)
   end
@@ -802,7 +821,8 @@ defmodule BDDCompiler.CLI do
         {:rerun_failures, :integer},
         {:skip_annotations_check, :boolean},
         {:skip_bdd_test, :boolean},
-        {:target, :string}
+        {:target, :string},
+        {:go_module, :string}
       ])
 
     {opts, rest, invalid} = OptionParser.parse(args, switches: switches)
@@ -828,7 +848,8 @@ defmodule BDDCompiler.CLI do
         :rerun_failures,
         :skip_annotations_check,
         :skip_bdd_test,
-        :target
+        :target,
+        :go_module
       ])
 
     required =

--- a/compiler/bddc/lib/bdd_compiler/instruction_set.ex
+++ b/compiler/bddc/lib/bdd_compiler/instruction_set.ex
@@ -146,14 +146,10 @@ defmodule BDDCompiler.InstructionSet do
     Enum.into(args, %{}, fn {k, v} ->
       arg_spec = %{
         type: v |> Map.get("type", "string") |> String.to_atom(),
-        required?: Map.get(v, "required", false)
+        required?: Map.get(v, "required", false),
+        # 确保 :allowed 键始终存在，避免 Validator 访问时 KeyError
+        allowed: Map.get(v, "allowed")
       }
-
-      arg_spec =
-        case Map.get(v, "allowed") do
-          nil -> arg_spec
-          list when is_list(list) -> Map.put(arg_spec, :allowed, list)
-        end
 
       {String.to_atom(k), arg_spec}
     end)

--- a/compiler/bddc/test/cli_go_integration_test.exs
+++ b/compiler/bddc/test/cli_go_integration_test.exs
@@ -1,0 +1,201 @@
+defmodule BDDCompiler.CLIGoIntegrationTest do
+  use ExUnit.Case, async: false
+
+  alias BDDCompiler.CLI
+
+  # 端到端 Go 编译集成测试
+
+  defp tmp_dir!(label) do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "bdd_go_integ_#{label}_#{System.unique_integer([:positive])}"
+      )
+
+    File.rm_rf!(dir)
+    File.mkdir_p!(dir)
+    dir
+  end
+
+  # 创建临时 DSL 文件和 instructions JSON
+  defp setup_project!(base) do
+    dsl_dir = Path.join(base, "docs/bdd")
+    File.mkdir_p!(dsl_dir)
+
+    # 简单的 DSL 文件
+    File.write!(Path.join(dsl_dir, "hello.dsl"), """
+    [SCENARIO: GO-INT-001] TITLE: go integration test
+    GIVEN setup_env name="test"
+    WHEN run_action id="1"
+    THEN verify_result status="ok"
+    """)
+
+    # 最小化的 instructions JSON manifest
+    json_path = Path.join(base, "instructions.json")
+
+    File.write!(json_path, """
+    {
+      "total": 3,
+      "entries": [
+        {
+          "name": "setup_env",
+          "domain": "Test",
+          "entity": "Env",
+          "source_kind": "action",
+          "source_name": "setup",
+          "kind": "given",
+          "dedup_index": 0,
+          "args": {"name": {"type": "string", "required": true}},
+          "outputs": {},
+          "scopes": ["integration"],
+          "boundary": "service"
+        },
+        {
+          "name": "run_action",
+          "domain": "Test",
+          "entity": "Action",
+          "source_kind": "action",
+          "source_name": "run",
+          "kind": "when",
+          "dedup_index": 0,
+          "args": {"id": {"type": "string", "required": true}},
+          "outputs": {},
+          "scopes": ["integration"],
+          "boundary": "service"
+        },
+        {
+          "name": "verify_result",
+          "domain": "Test",
+          "entity": "Result",
+          "source_kind": "read",
+          "source_name": "verify",
+          "kind": "then",
+          "dedup_index": 0,
+          "args": {"status": {"type": "string", "required": true}},
+          "outputs": {},
+          "scopes": ["integration"],
+          "boundary": "service"
+        }
+      ]
+    }
+    """)
+
+    {dsl_dir, json_path}
+  end
+
+  describe "--target go 端到端编译" do
+    test "生成 Go 测试文件，包含正确的 package 和 import" do
+      base = tmp_dir!("go_e2e")
+      {dsl_dir, json_path} = setup_project!(base)
+      out_dir = Path.join(base, "out")
+
+      # 通过 CLI.main 调用完整编译流程
+      CLI.main([
+        "compile",
+        "--target", "go",
+        "--go-module", "github.com/test/app",
+        "--instructions-json", json_path,
+        "--in", dsl_dir,
+        "--out", out_dir
+      ])
+
+      # 验证输出文件是 _generated_test.go（而非 .exs）
+      go_files = Path.join(out_dir, "*_generated_test.go") |> Path.wildcard()
+      assert length(go_files) == 1, "应生成恰好 1 个 Go 测试文件，实际: #{inspect(go_files)}"
+
+      content = File.read!(List.first(go_files))
+
+      # 验证 Go package 声明
+      assert content =~ "package bdd_test"
+
+      # 验证 import 包含指定的 go_module 路径
+      assert content =~ "github.com/test/app/bdd/runtime"
+
+      # 验证不存在 .exs 文件
+      exs_files = Path.join(out_dir, "*_generated_test.exs") |> Path.wildcard()
+      assert exs_files == [], "Go target 不应生成 .exs 文件"
+    end
+
+    test "默认 target（无 --target 标志）仍输出 .exs" do
+      base = tmp_dir!("default_target")
+      {dsl_dir, json_path} = setup_project!(base)
+      out_dir = Path.join(base, "out")
+
+      # 不指定 --target，应默认 elixir
+      CLI.main([
+        "compile",
+        "--instructions-json", json_path,
+        "--in", dsl_dir,
+        "--out", out_dir
+      ])
+
+      exs_files = Path.join(out_dir, "*_generated_test.exs") |> Path.wildcard()
+      assert length(exs_files) == 1, "默认应生成 .exs 文件"
+
+      go_files = Path.join(out_dir, "*_generated_test.go") |> Path.wildcard()
+      assert go_files == [], "默认不应生成 Go 文件"
+    end
+  end
+
+  describe ".bddc.toml 配置支持" do
+    test "从 .bddc.toml 读取 target 和 go_module 作为默认值" do
+      base = tmp_dir!("toml_defaults")
+      {dsl_dir, json_path} = setup_project!(base)
+      out_dir = Path.join(base, "out")
+
+      # 写入 .bddc.toml 到项目根目录
+      File.write!(Path.join(base, ".bddc.toml"), """
+      [global]
+      target = "go"
+      go_module = "github.com/toml/example"
+      """)
+
+      # 不在 CLI 指定 --target 和 --go-module，依赖 .bddc.toml
+      CLI.main([
+        "compile",
+        "--project-root", base,
+        "--instructions-json", json_path,
+        "--in", dsl_dir,
+        "--out", out_dir
+      ])
+
+      go_files = Path.join(out_dir, "*_generated_test.go") |> Path.wildcard()
+      assert length(go_files) == 1, ".bddc.toml 中 target=go 应生成 Go 文件"
+
+      content = File.read!(List.first(go_files))
+      assert content =~ "github.com/toml/example/bdd/runtime"
+    end
+
+    test "CLI 标志覆盖 .bddc.toml 中的配置" do
+      base = tmp_dir!("toml_override")
+      {dsl_dir, json_path} = setup_project!(base)
+      out_dir = Path.join(base, "out")
+
+      # .bddc.toml 指定 go target
+      File.write!(Path.join(base, ".bddc.toml"), """
+      [global]
+      target = "go"
+      go_module = "github.com/toml/default"
+      """)
+
+      # CLI 用 --go-module 覆盖
+      CLI.main([
+        "compile",
+        "--project-root", base,
+        "--target", "go",
+        "--go-module", "github.com/cli/override",
+        "--instructions-json", json_path,
+        "--in", dsl_dir,
+        "--out", out_dir
+      ])
+
+      go_files = Path.join(out_dir, "*_generated_test.go") |> Path.wildcard()
+      assert length(go_files) == 1
+
+      content = File.read!(List.first(go_files))
+      # CLI 标志应覆盖 toml 值
+      assert content =~ "github.com/cli/override/bdd/runtime"
+      refute content =~ "github.com/toml/default"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `--go-module` CLI parameter for Go module path in imports
- Add `.bddc.toml` support for `target` and `go_module` settings
- Integration test for end-to-end Go compilation via CLI
- Fix: ensure JSON-loaded instruction args always include `:allowed` key

Closes #520

## Test plan
- [x] `--target go --go-module ...` produces correct Go output
- [x] `.bddc.toml` target/go_module read as defaults
- [x] CLI flags override `.bddc.toml` values
- [x] Default target (elixir) unchanged — backward compatible
- [x] All 54 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)