### PR TITLE
fix: bddc 递归扫描 DSL

### DIFF
--- a/compiler/bddc/lib/bdd_compiler/compiler.ex
+++ b/compiler/bddc/lib/bdd_compiler/compiler.ex
@@ -38,11 +38,7 @@ defmodule BDDCompiler.Compiler do
         :error -> default_docs_root(in_dir)
       end
 
-    dsl_paths =
-      in_dir
-      |> Path.join("*.dsl")
-      |> Path.wildcard()
-      |> Enum.sort()
+    dsl_paths = discover_dsl_paths(in_dir)
 
     md_paths =
       if is_binary(docs_root) do
@@ -112,6 +108,14 @@ defmodule BDDCompiler.Compiler do
     end
   end
 
+  # 兼容平铺目录，同时支持 docs/bdd/**/*.dsl 的嵌套布局。
+  defp discover_dsl_paths(in_dir) do
+    in_dir
+    |> Path.join("**/*.dsl")
+    |> Path.wildcard()
+    |> Enum.sort()
+  end
+
   defp assert_unique_scenario_ids!(parsed) when is_list(parsed) do
     parsed
     |> Enum.flat_map(fn {_source_id, _validate_path, _module_base, scenarios} -> scenarios end)
@@ -136,4 +140,3 @@ defmodule BDDCompiler.Compiler do
     :ok
   end
 end
-

--- a/compiler/bddc/test/cli_pipeline_test.exs
+++ b/compiler/bddc/test/cli_pipeline_test.exs
@@ -16,6 +16,21 @@ defmodule BDDCompiler.CLIPipelineTest do
     dir
   end
 
+  defp write_nested_dsl_fixture!(root) do
+    nested_dir = Path.join(root, "docs/bdd/features")
+    File.mkdir_p!(nested_dir)
+
+    File.write!(
+      Path.join(nested_dir, "nested.dsl"),
+      """
+      [SCENARIO: FX-NESTED-001] TITLE: nested dsl TAGS: smoke
+      GIVEN given_seed id="seed-nested"
+      WHEN when_do id=$id
+      THEN assert_done id=$id
+      """
+    )
+  end
+
   test "缺少指令来源时 compile 失败" do
     {out, status} =
       System.cmd(@escript, ["compile", "--in", "docs/bdd", "--out", "/tmp/bdd_compiler_missing_src"],
@@ -53,6 +68,38 @@ defmodule BDDCompiler.CLIPipelineTest do
     assert status == 0
     assert out =~ "BDD 编译完成"
     assert File.exists?(Path.join(out_dir, "simple_generated_test.exs"))
+  end
+
+  test "compile 会递归扫描 docs/bdd/**/*.dsl" do
+    root = tmp_dir!("nested_compile_project")
+    File.cp_r!(@fixture_project, root)
+    write_nested_dsl_fixture!(root)
+    out_dir = Path.join(root, "tmp_out")
+
+    {out, status} =
+      System.cmd(
+        @escript,
+        [
+          "compile",
+          "--project-root",
+          root,
+          "--registry-module",
+          "Fixture.BDD.InstructionRegistry",
+          "--runtime-module",
+          "Fixture.BDD.Instructions.V1",
+          "--in",
+          "docs/bdd",
+          "--out",
+          out_dir
+        ],
+        cd: Path.expand("..", __DIR__),
+        stderr_to_stdout: true
+      )
+
+    assert status == 0
+    assert out =~ "BDD 编译完成"
+    assert File.exists?(Path.join(out_dir, "simple_generated_test.exs"))
+    assert File.exists?(Path.join(out_dir, "nested_generated_test.exs"))
   end
 
   test "check 在 runtime 不实现 capabilities/0 时失败" do


### PR DESCRIPTION
Summary:
- 将 `compile_dir!/4` 的 DSL 发现逻辑改为递归扫描 `**/*.dsl`
- 保持平铺 `docs/bdd/*.dsl` 布局兼容
- 补充 `docs/bdd/features/*.dsl` 回归测试

Test plan:
- `cd compiler/bddc && mix test test/cli_pipeline_test.exs`
- 验证 `compile --in docs/bdd` 同时产出平铺与嵌套 DSL 的生成测试文件

Closes #528