### PR TITLE
fix: prefer features dsl discovery in bddc compile

### DIFF
--- a/compiler/bddc/lib/bdd_compiler/compiler.ex
+++ b/compiler/bddc/lib/bdd_compiler/compiler.ex
@@ -35,11 +35,7 @@ defmodule BDDCompiler.Compiler do
         :error -> default_docs_root(in_dir)
       end
 
-    dsl_paths =
-      in_dir
-      |> Path.join("*.dsl")
-      |> Path.wildcard()
-      |> Enum.sort()
+    dsl_paths = discover_dsl_paths(in_dir)
 
     md_paths =
       if is_binary(docs_root) do
@@ -93,6 +89,37 @@ defmodule BDDCompiler.Compiler do
     end
   end
 
+  # 优先消费 bcc organize 产出的 features/*.dsl，避免与 scenarios/*.dsl 重复读入同一 scenario。
+  # 若不存在 features 目录，则兼容历史结构：根目录 *.dsl；再回退到递归扫描。
+  defp discover_dsl_paths(in_dir) when is_binary(in_dir) do
+    feature_paths =
+      in_dir
+      |> Path.join("features/**/*.dsl")
+      |> Path.wildcard()
+      |> Enum.sort()
+
+    cond do
+      feature_paths != [] ->
+        feature_paths
+
+      true ->
+        root_paths =
+          in_dir
+          |> Path.join("*.dsl")
+          |> Path.wildcard()
+          |> Enum.sort()
+
+        if root_paths != [] do
+          root_paths
+        else
+          in_dir
+          |> Path.join("**/*.dsl")
+          |> Path.wildcard()
+          |> Enum.sort()
+        end
+    end
+  end
+
   defp assert_unique_scenario_ids!(parsed) when is_list(parsed) do
     parsed
     |> Enum.flat_map(fn {_source_id, _validate_path, _module_base, scenarios} -> scenarios end)
@@ -117,4 +144,3 @@ defmodule BDDCompiler.Compiler do
     :ok
   end
 end
-

--- a/compiler/bddc/test/cli_pipeline_test.exs
+++ b/compiler/bddc/test/cli_pipeline_test.exs
@@ -55,6 +55,53 @@ defmodule BDDCompiler.CLIPipelineTest do
     assert File.exists?(Path.join(out_dir, "simple_generated_test.exs"))
   end
 
+  test "compile 会递归扫描 docs/bdd 子目录下的 dsl 文件" do
+    project_root = tmp_dir!("compile_nested_project")
+    out_dir = tmp_dir!("compile_nested_out")
+    nested_dir = Path.join(project_root, "docs/bdd/features")
+    File.mkdir_p!(nested_dir)
+
+    File.write!(
+      Path.join(nested_dir, "simple.dsl"),
+      """
+      [SCENARIO: FX-NESTED-001] TITLE: nested fixture flow TAGS: integration
+      GIVEN given_seed id="seed-1"
+      WHEN when_do id=$id
+      THEN assert_done id=$id
+      """
+    )
+
+    File.cp!(Path.join(@fixture_project, "mix.exs"), Path.join(project_root, "mix.exs"))
+    File.mkdir_p!(Path.join(project_root, "lib"))
+    File.cp_r!(Path.join(@fixture_project, "lib/bdd_compiler"), Path.join(project_root, "lib/bdd_compiler"))
+    File.mkdir_p!(Path.join(project_root, "test/support"))
+    File.cp_r!(Path.join(@fixture_project, "test/support/bdd"), Path.join(project_root, "test/support/bdd"))
+
+    {out, status} =
+      System.cmd(
+        @escript,
+        [
+          "compile",
+          "--project-root",
+          project_root,
+          "--registry-module",
+          "Fixture.BDD.InstructionRegistry",
+          "--runtime-module",
+          "Fixture.BDD.Instructions.V1",
+          "--in",
+          "docs/bdd",
+          "--out",
+          out_dir
+        ],
+        cd: Path.expand("..", __DIR__),
+        stderr_to_stdout: true
+      )
+
+    assert status == 0
+    assert out =~ "BDD 编译完成"
+    assert File.exists?(Path.join(out_dir, "simple_generated_test.exs"))
+  end
+
   test "check 在 runtime 不实现 capabilities/0 时失败" do
     {out, status} =
       System.cmd(


### PR DESCRIPTION
## Summary
- prefer `docs/bdd/features/**/*.dsl` when present so bddc can consume `bcc bdd seed -s organize` output
- keep backward compatibility for legacy root-level `docs/bdd/*.dsl` inputs
- add a regression test covering nested `features/` discovery

## Test plan
- rebuilt `compiler/bddc/bdd_compiler` with `mix escript.build`
- ran `bdd_compiler compile` against `travel/docs/bdd` in the #989 POC
- verified output changed from `0` generated tests to `1415` generated tests

Closes #530