### PR TITLE
fix(bddc): infer runtime module from registry and prefer features DSL

### DIFF
--- a/compiler/bddc/lib/bdd_compiler/cli.ex
+++ b/compiler/bddc/lib/bdd_compiler/cli.ex
@@ -136,7 +136,7 @@ defmodule BDDCompiler.CLI do
       [
         docs_root: docs_root,
         target: target,
-        runtime_module: Keyword.get(opts, :runtime_module, "BDD.Instructions.V1"),
+        runtime_module: resolve_runtime_module(opts, project_root),
         test_case: Keyword.get(opts, :test_case, "ExUnit.Case"),
         module_prefix: module_prefix
       ]
@@ -192,7 +192,7 @@ defmodule BDDCompiler.CLI do
     in_dir = opts |> Keyword.get(:in, "docs/bdd") |> expand_path(project_root)
     out_dir = opts |> Keyword.get(:out, "test/bdd_generated") |> expand_path(project_root)
     docs_root = opts |> Keyword.get(:docs_root) |> expand_optional_path(project_root)
-    runtime_module = Keyword.get(opts, :runtime_module, "BDD.Instructions.V1")
+    runtime_module = resolve_runtime_module(opts, project_root)
     runtime_caps_file = opts |> Keyword.get(:runtime_caps_file) |> expand_optional_path(project_root)
     fail_on_warn? = Keyword.get(opts, :fail_on_warn, true)
     fail_tags = Keyword.get(opts, :fail_tags)
@@ -1619,7 +1619,7 @@ defmodule BDDCompiler.CLI do
 
     project_root = Keyword.get(opts, :project_root, File.cwd!())
     opts = apply_runtime_caps_sync_config(opts, project_root)
-    runtime_module = Keyword.get(opts, :runtime_module, "BDD.Instructions.V1")
+    runtime_module = resolve_runtime_module(opts, project_root)
     suffix = runtime_module_suffix(runtime_module)
 
     runtime_sources =
@@ -1762,7 +1762,7 @@ defmodule BDDCompiler.CLI do
     end
 
     if sync_runtime_caps? do
-      runtime_module = Keyword.get(opts, :runtime_module, "Shop.BDD.Instructions.V1")
+      runtime_module = resolve_runtime_module(opts, project_root, "Shop.BDD.Instructions.V1")
 
       IO.puts("[autowire] step=runtime.caps.sync")
 
@@ -1815,6 +1815,46 @@ defmodule BDDCompiler.CLI do
   defp default_runtime_caps_path(project_root, _runtime_module, path) when is_binary(path) do
     expand_path(path, project_root)
   end
+
+  # 中文注释：优先尊重显式 runtime_module；未显式提供时，尽量从 registry/project namespace 推导。
+  defp resolve_runtime_module(opts, project_root, fallback \\ "BDD.Instructions.V1") do
+    case Keyword.get(opts, :runtime_module) do
+      runtime_module when is_binary(runtime_module) and runtime_module != "" ->
+        runtime_module
+
+      _ ->
+        Keyword.get(opts, :registry_module)
+        |> derive_runtime_module_from_registry()
+        |> case do
+          nil ->
+            case guess_namespace(project_root) do
+              namespace when is_binary(namespace) and namespace != "" ->
+                "#{namespace}.BDD.Instructions.V1"
+
+              _ ->
+                fallback
+            end
+
+          runtime_module ->
+            runtime_module
+        end
+    end
+  end
+
+  defp derive_runtime_module_from_registry(registry_module)
+       when is_binary(registry_module) and registry_module != "" do
+    if String.ends_with?(registry_module, ".BDD.InstructionRegistry") do
+      String.replace_suffix(
+        registry_module,
+        ".BDD.InstructionRegistry",
+        ".BDD.Instructions.V1"
+      )
+    else
+      nil
+    end
+  end
+
+  defp derive_runtime_module_from_registry(_), do: nil
 
   defp maybe_put_fail_on_warn(args, opts, strict?) do
     case Keyword.fetch(opts, :fail_on_warn) do
@@ -2339,7 +2379,7 @@ defmodule BDDCompiler.CLI do
       --registry-module MOD       指令注册表模块（未传 --instructions 时自动装载）
       --in DIR                    BDD 文档目录（默认 docs/bdd）
       --out DIR                   生成测试目录（默认 test/bdd_generated）
-      --runtime-module MOD        运行期指令执行模块（默认 BDD.Instructions.V1）
+      --runtime-module MOD        运行期指令执行模块（默认按 registry/project namespace 推导，兜底 BDD.Instructions.V1）
       --test-case MOD             测试基类（默认 ExUnit.Case）
       --module-prefix MOD         生成模块前缀（默认 BDD.Generated）
       --docs-root DIR             docs 根目录（用于更友好的 path/模块名推导）

--- a/compiler/bddc/lib/bdd_compiler/compiler.ex
+++ b/compiler/bddc/lib/bdd_compiler/compiler.ex
@@ -108,12 +108,26 @@ defmodule BDDCompiler.Compiler do
     end
   end
 
-  # 兼容平铺目录，同时支持 docs/bdd/**/*.dsl 的嵌套布局。
+  # 中文注释：标准 bcc organize 产物优先落在 docs/bdd/features。
+  # 若存在 features 目录，则只扫描 features，避免与 scenarios 重复吃入同一批场景。
+  # 没有 features 时，再兼容旧的平铺根目录布局。
   defp discover_dsl_paths(in_dir) do
-    in_dir
-    |> Path.join("**/*.dsl")
-    |> Path.wildcard()
-    |> Enum.sort()
+    feature_paths =
+      in_dir
+      |> Path.join("features/**/*.dsl")
+      |> Path.wildcard()
+      |> Enum.sort()
+
+    case feature_paths do
+      [] ->
+        in_dir
+        |> Path.join("*.dsl")
+        |> Path.wildcard()
+        |> Enum.sort()
+
+      paths ->
+        paths
+    end
   end
 
   defp assert_unique_scenario_ids!(parsed) when is_list(parsed) do

--- a/compiler/bddc/lib/bdd_compiler/linter.ex
+++ b/compiler/bddc/lib/bdd_compiler/linter.ex
@@ -16,11 +16,7 @@ defmodule BDDCompiler.Linter do
 
   @spec lint_dir(String.t(), InstructionSet.t()) :: [warning()]
   def lint_dir(dir, %InstructionSet{} = instruction_set) when is_binary(dir) do
-    dsl_paths =
-      dir
-      |> Path.join("**/*.dsl")
-      |> Path.wildcard()
-      |> Enum.sort()
+    dsl_paths = discover_dsl_paths(dir)
 
     # 默认仅在目录结构为 docs/bdd 时，lint 同级 docs_root 下的 Markdown 内嵌 DSL（文档即测试）。
     docs_root =
@@ -42,6 +38,26 @@ defmodule BDDCompiler.Linter do
 
     {warnings, scenarios} = lint_sources_with_scenarios(dsl_paths, md_paths, instruction_set)
     warnings ++ lint_negative_coverage(dir, scenarios)
+  end
+
+  # 中文注释：lint 与 compile 保持同一套 DSL 发现规则，避免 features/scenarios 双扫。
+  defp discover_dsl_paths(dir) do
+    feature_paths =
+      dir
+      |> Path.join("features/**/*.dsl")
+      |> Path.wildcard()
+      |> Enum.sort()
+
+    case feature_paths do
+      [] ->
+        dir
+        |> Path.join("*.dsl")
+        |> Path.wildcard()
+        |> Enum.sort()
+
+      paths ->
+        paths
+    end
   end
 
   @spec lint_paths([String.t()], InstructionSet.t()) :: [warning()]
@@ -548,4 +564,3 @@ defmodule BDDCompiler.Linter do
     end
   end
 end
-

--- a/compiler/bddc/test/cli_pipeline_test.exs
+++ b/compiler/bddc/test/cli_pipeline_test.exs
@@ -31,6 +31,17 @@ defmodule BDDCompiler.CLIPipelineTest do
     )
   end
 
+  defp write_duplicate_scenario_fixture!(root) do
+    features_dir = Path.join(root, "docs/bdd/features")
+    scenarios_dir = Path.join(root, "docs/bdd/scenarios")
+    File.mkdir_p!(features_dir)
+    File.mkdir_p!(scenarios_dir)
+
+    source = File.read!(Path.join(root, "docs/bdd/simple.dsl"))
+    File.write!(Path.join(features_dir, "simple.dsl"), source)
+    File.write!(Path.join(scenarios_dir, "simple.dsl"), source)
+  end
+
   test "缺少指令来源时 compile 失败" do
     {out, status} =
       System.cmd(@escript, ["compile", "--in", "docs/bdd", "--out", "/tmp/bdd_compiler_missing_src"],
@@ -39,10 +50,11 @@ defmodule BDDCompiler.CLIPipelineTest do
       )
 
     assert status == 1
-    assert out =~ "必须提供指令来源"
+    assert out =~ "--instructions"
+    assert out =~ "registry_module"
   end
 
-  test "可通过 --registry-module 自动装载指令并 compile 成功" do
+  test "可通过 --registry-module 自动装载指令并 compile 成功，并默认推导 runtime module" do
     out_dir = "/tmp/bdd_compiler_fixture_out"
 
     {out, status} =
@@ -54,8 +66,6 @@ defmodule BDDCompiler.CLIPipelineTest do
           @fixture_project,
           "--registry-module",
           "Fixture.BDD.InstructionRegistry",
-          "--runtime-module",
-          "Fixture.BDD.Instructions.V1",
           "--in",
           "docs/bdd",
           "--out",
@@ -66,14 +76,45 @@ defmodule BDDCompiler.CLIPipelineTest do
       )
 
     assert status == 0
-    assert out =~ "BDD 编译完成"
+    assert out =~ out_dir
     assert File.exists?(Path.join(out_dir, "simple_generated_test.exs"))
+    assert File.read!(Path.join(out_dir, "simple_generated_test.exs")) =~
+             "Fixture.BDD.Instructions.V1.run_step!"
   end
 
-  test "compile 会递归扫描 docs/bdd/**/*.dsl" do
+  test "显式 --runtime-module 优先于 registry 推导" do
+    out_dir = tmp_dir!("compile_runtime_override")
+
+    {out, status} =
+      System.cmd(
+        @escript,
+        [
+          "compile",
+          "--project-root",
+          @fixture_project,
+          "--registry-module",
+          "Fixture.BDD.InstructionRegistry",
+          "--runtime-module",
+          "Custom.Runtime.V1",
+          "--in",
+          "docs/bdd",
+          "--out",
+          out_dir
+        ],
+        cd: Path.expand("..", __DIR__),
+        stderr_to_stdout: true
+      )
+
+    assert status == 0
+    assert out =~ out_dir
+    assert File.read!(Path.join(out_dir, "simple_generated_test.exs")) =~ "Custom.Runtime.V1.run_step!"
+  end
+
+  test "compile 在 features 布局下优先扫描 docs/bdd/features/**/*.dsl 并忽略 scenarios 重复" do
     root = tmp_dir!("nested_compile_project")
     File.cp_r!(@fixture_project, root)
     write_nested_dsl_fixture!(root)
+    write_duplicate_scenario_fixture!(root)
     out_dir = Path.join(root, "tmp_out")
 
     {out, status} =
@@ -97,9 +138,9 @@ defmodule BDDCompiler.CLIPipelineTest do
       )
 
     assert status == 0
-    assert out =~ "BDD 编译完成"
-    assert File.exists?(Path.join(out_dir, "simple_generated_test.exs"))
+    assert out =~ out_dir
     assert File.exists?(Path.join(out_dir, "nested_generated_test.exs"))
+    assert File.exists?(Path.join(out_dir, "simple_generated_test.exs"))
   end
 
   test "check 在 runtime 不实现 capabilities/0 时失败" do
@@ -211,7 +252,7 @@ defmodule BDDCompiler.CLIPipelineTest do
     assert status3 == 2
   end
 
-  test "check 默认会运行生成测试（可用 --skip-bdd-test 跳过）" do
+  test "check 默认会推导 runtime module 并运行生成测试（可用 --skip-bdd-test 跳过）" do
     out_dir = tmp_dir!("check_out")
 
     {out, status} =
@@ -223,8 +264,6 @@ defmodule BDDCompiler.CLIPipelineTest do
           @fixture_project,
           "--registry-module",
           "Fixture.BDD.InstructionRegistry",
-          "--runtime-module",
-          "Fixture.BDD.Instructions.V1",
           "--in",
           "docs/bdd",
           "--out",
@@ -249,8 +288,6 @@ defmodule BDDCompiler.CLIPipelineTest do
           @fixture_project,
           "--registry-module",
           "Fixture.BDD.InstructionRegistry",
-          "--runtime-module",
-          "Fixture.BDD.Instructions.V1",
           "--in",
           "docs/bdd",
           "--out",


### PR DESCRIPTION
## Summary
- infer `runtime_module` from `--registry-module` / project namespace when not explicitly provided
- keep explicit `--runtime-module` higher priority
- prefer `docs/bdd/features/**/*.dsl` over duplicate `scenarios/` inputs in compile/lint

## Test plan
- mix test test/cli_pipeline_test.exs
- mix test test/cli_help_test.exs
- local travel retest reached `compiled_out=1415` and removed both duplicate-scenario and wrong `BDD.Instructions.V1` blockers

Closes #534