### PR TITLE
fix: exempt single-step workflow from weak assertion metric

### DIFF
--- a/compiler/bddc/lib/bdd_compiler/linter.ex
+++ b/compiler/bddc/lib/bdd_compiler/linter.ex
@@ -166,7 +166,8 @@ defmodule BDDCompiler.Linter do
     weak? = fn spec -> spec.assert_class in [:weak, nil] end
 
     if then_steps != [] and Enum.all?(then_specs, weak?) and
-         not strong_seed_contract_assertion?(then_steps, seed_contract) do
+         not strong_seed_contract_assertion?(then_steps, seed_contract) and
+         not exempt_seed_contract_weak_assertion?(then_steps, seed_contract) do
       meta = elem(List.first(then_steps), 3)
 
       [
@@ -272,6 +273,24 @@ defmodule BDDCompiler.Linter do
   end
 
   defp strong_seed_contract_assertion?(_then_steps, _), do: false
+
+  defp exempt_seed_contract_weak_assertion?(then_steps, %SeedContract{} = seed_contract) do
+    has_seed_then? =
+      Enum.any?(then_steps, fn
+        {:then, :then_seed_contract_should_hold, _args, _meta} -> true
+        _ -> false
+      end)
+
+    has_seed_then? and seed_contract_expected_weak?(seed_contract)
+  end
+
+  defp exempt_seed_contract_weak_assertion?(_then_steps, _), do: false
+
+  defp seed_contract_expected_weak?(%SeedContract{edge_class: "workflow_contract"} = contract) do
+    length(contract.action_path) == 1 and contract.branch_hints == []
+  end
+
+  defp seed_contract_expected_weak?(%SeedContract{}), do: false
 
   defp seed_contract_sufficient?(%SeedContract{edge_class: "workflow_contract"} = contract) do
     length(contract.action_path) >= 2 or contract.branch_hints != []

--- a/compiler/bddc/test/linter_test.exs
+++ b/compiler/bddc/test/linter_test.exs
@@ -93,7 +93,7 @@ defmodule BDDCompiler.LinterTest do
     refute Enum.any?(warnings, &(&1.rule == :weak_assertion))
   end
 
-  test "workflow single-step seed contract remains weak" do
+  test "workflow single-step seed contract is exempt from weak assertion metric" do
     root = temp_dir("bddc_linter_workflow_weak")
     features_dir = Path.join(root, "features")
 
@@ -124,7 +124,8 @@ defmodule BDDCompiler.LinterTest do
     )
 
     warnings = Linter.lint_dir(root, instruction_set())
-    assert Enum.any?(
+
+    refute Enum.any?(
              warnings,
              &(&1.rule == :weak_assertion and
                  &1.scenario_id ==


### PR DESCRIPTION
Summary
- exempt single-step workflow seed contracts from `weak_assertion` main metric
- keep `workflow_contract` semantic classification unchanged
- update linter regression to assert the scenario no longer counts as weak

Test plan
- `cd compiler/bddc && mix test test/linter_test.exs`

Closes #538