### PR TITLE
feat: bddc lint 检测 determination/reactor 潜在降级通过 (unibo#1316)

### DIFF
--- a/compiler/bddc/lib/bdd_compiler/linter.ex
+++ b/compiler/bddc/lib/bdd_compiler/linter.ex
@@ -100,6 +100,7 @@ defmodule BDDCompiler.Linter do
     warns = warns ++ lint_impl_detail_reference(id, tags, steps)
     warns = warns ++ lint_unique_risk(id, tags, steps)
     warns = warns ++ lint_pure_snapshot(id, tags, steps)
+    warns = warns ++ lint_degraded_contract(id, tags, steps, seed_contract)
     warns ++ lint_async_without_eventually(id, tags, steps, version, instruction_set)
   end
 
@@ -729,6 +730,55 @@ defmodule BDDCompiler.Linter do
       end
     end
   end
+
+  # 规则：determination_contract / reactor_contract 潜在降级通过告警。
+  #
+  # BDD runtime 在这两类合约降级通过时会在 facts 中打 :degraded 标记（PR #1362）。
+  # lint 阶段无法执行测试，但可以静态标记：凡是 edge_class 为这两类的 seed contract 场景，
+  # 提示用户确认 compile-project 已重跑，以免降级路径被忽略。
+  #
+  # 只在场景使用了 then_seed_contract_should_hold 时触发（否则不涉及合约断言）。
+  @degraded_edge_classes ~w[determination_contract reactor_contract]
+
+  defp lint_degraded_contract(scenario_id, tags, steps, %SeedContract{edge_class: edge_class})
+       when edge_class in @degraded_edge_classes do
+    has_seed_then? =
+      Enum.any?(steps, fn
+        {:then, :then_seed_contract_should_hold, _args, _meta} -> true
+        _ -> false
+      end)
+
+    if has_seed_then? do
+      rule =
+        if edge_class == "determination_contract",
+          do: :determination_degraded_pass,
+          else: :reactor_degraded_pass
+
+      meta =
+        Enum.find_value(steps, fn
+          {:then, :then_seed_contract_should_hold, _args, meta} -> meta
+          _ -> nil
+        end) || %{}
+
+      [
+        %Warning{
+          rule: rule,
+          scenario_id: scenario_id,
+          tags: tags,
+          file: meta[:file],
+          line: meta[:line],
+          raw: meta[:raw],
+          message:
+            "此场景的 edge_class 为 #{edge_class}，BDD runtime 可能以降级模式通过（facts 含 :degraded）。" <>
+              "请确认 compile-project 已重跑，并检查实际 facts 不含 :degraded 标记。"
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  defp lint_degraded_contract(_scenario_id, _tags, _steps, _seed_contract), do: []
 
   # 规则：唯一性风险提示（默认仅在 TAGS 含 strict_unique 时启用）。
   # 仅做最小启发式：对可能触发唯一约束的 string 字段（如 product_id）如果是纯常量且未包含 run_id 痕迹，提示改用 run_id() 拼接。

--- a/compiler/bddc/test/linter_test.exs
+++ b/compiler/bddc/test/linter_test.exs
@@ -170,6 +170,156 @@ defmodule BDDCompiler.LinterTest do
     refute Enum.any?(warnings, &(&1.rule == :weak_assertion))
   end
 
+  test "determination_contract seed 场景触发 determination_degraded_pass 告警" do
+    root = temp_dir("bddc_linter_determination_degraded")
+    features_dir = Path.join(root, "features")
+    contexts_dir = Path.join(root, "contexts")
+
+    write(
+      Path.join(features_dir, "order_determination.dsl"),
+      """
+      [SCENARIO: BDD-ORDER_DETERMINATION-SEED-order_det_check] TITLE: check TAGS: seed determination_contract
+      GIVEN given_seed_context id="order_det_check" module="ORDER_DETERMINATION"
+      WHEN when_execute_seed_contract module="ORDER_DETERMINATION"
+      THEN then_seed_contract_should_hold module="ORDER_DETERMINATION"
+      """
+    )
+
+    write(
+      Path.join(contexts_dir, "order_det_check.json"),
+      ~s|{
+        "id": "order_det_check",
+        "module": "ORDER_DETERMINATION",
+        "edge_class": "determination_contract",
+        "expected_facts": ["rule_matched"],
+        "action_path": [],
+        "branch_hints": [],
+        "declared_error_codes": [],
+        "business_post_conditions": []
+      }|
+    )
+
+    warnings = Linter.lint_dir(root, instruction_set())
+
+    assert Enum.any?(
+             warnings,
+             &(&1.rule == :determination_degraded_pass and
+                 &1.scenario_id == "BDD-ORDER_DETERMINATION-SEED-order_det_check")
+           )
+  end
+
+  test "reactor_contract seed 场景触发 reactor_degraded_pass 告警" do
+    root = temp_dir("bddc_linter_reactor_degraded")
+    features_dir = Path.join(root, "features")
+    contexts_dir = Path.join(root, "contexts")
+
+    write(
+      Path.join(features_dir, "payment_reactor.dsl"),
+      """
+      [SCENARIO: BDD-PAYMENT_REACTOR-SEED-payment_react_handle] TITLE: handle TAGS: seed reactor_contract
+      GIVEN given_seed_context id="payment_react_handle" module="PAYMENT_REACTOR"
+      WHEN when_execute_seed_contract module="PAYMENT_REACTOR"
+      THEN then_seed_contract_should_hold module="PAYMENT_REACTOR"
+      """
+    )
+
+    write(
+      Path.join(contexts_dir, "payment_react_handle.json"),
+      ~s|{
+        "id": "payment_react_handle",
+        "module": "PAYMENT_REACTOR",
+        "edge_class": "reactor_contract",
+        "expected_facts": ["event_handled"],
+        "action_path": [],
+        "branch_hints": [],
+        "declared_error_codes": [],
+        "business_post_conditions": []
+      }|
+    )
+
+    warnings = Linter.lint_dir(root, instruction_set())
+
+    assert Enum.any?(
+             warnings,
+             &(&1.rule == :reactor_degraded_pass and
+                 &1.scenario_id == "BDD-PAYMENT_REACTOR-SEED-payment_react_handle")
+           )
+  end
+
+  test "action_contract 场景不触发 degraded 告警" do
+    root = temp_dir("bddc_linter_no_degraded_for_action")
+    features_dir = Path.join(root, "features")
+    contexts_dir = Path.join(root, "contexts")
+
+    write(
+      Path.join(features_dir, "order_submit.dsl"),
+      """
+      [SCENARIO: BDD-ORDER_ORDER-SEED-order_submit] TITLE: submit TAGS: seed action_contract
+      GIVEN given_seed_context id="order_submit" module="ORDER_ORDER"
+      WHEN when_execute_seed_contract module="ORDER_ORDER"
+      THEN then_seed_contract_should_hold module="ORDER_ORDER"
+      """
+    )
+
+    write(
+      Path.join(contexts_dir, "order_submit.json"),
+      ~s|{
+        "id": "order_submit",
+        "module": "ORDER_ORDER",
+        "edge_class": "action_contract",
+        "expected_facts": ["record_persisted"],
+        "action_path": [],
+        "branch_hints": [],
+        "declared_error_codes": [],
+        "business_post_conditions": []
+      }|
+    )
+
+    warnings = Linter.lint_dir(root, instruction_set())
+
+    refute Enum.any?(
+             warnings,
+             &(&1.rule in [:determination_degraded_pass, :reactor_degraded_pass])
+           )
+  end
+
+  test "determination_contract 无 then_seed_contract_should_hold 时不触发 degraded 告警" do
+    root = temp_dir("bddc_linter_no_seed_then_no_degraded")
+    features_dir = Path.join(root, "features")
+    contexts_dir = Path.join(root, "contexts")
+
+    write(
+      Path.join(features_dir, "det_no_hold.dsl"),
+      """
+      [SCENARIO: BDD-ORDER_DETERMINATION-MANUAL-order_det_manual] TITLE: manual TAGS: integration determination_contract
+      GIVEN given_seed_context id="order_det_manual" module="ORDER_DETERMINATION"
+      WHEN when_execute_seed_contract module="ORDER_DETERMINATION"
+      THEN assert_noop
+      """
+    )
+
+    write(
+      Path.join(contexts_dir, "order_det_manual.json"),
+      ~s|{
+        "id": "order_det_manual",
+        "module": "ORDER_DETERMINATION",
+        "edge_class": "determination_contract",
+        "expected_facts": [],
+        "action_path": [],
+        "branch_hints": [],
+        "declared_error_codes": [],
+        "business_post_conditions": []
+      }|
+    )
+
+    warnings = Linter.lint_dir(root, instruction_set())
+
+    refute Enum.any?(
+             warnings,
+             &(&1.rule in [:determination_degraded_pass, :reactor_degraded_pass])
+           )
+  end
+
   test "stale context falls back to priv/bdd/sources structured fields" do
     root = temp_dir("bddc_linter_seed_source_fallback")
     features_dir = Path.join(root, "docs/bdd/features")


### PR DESCRIPTION
linter.ex 新增 lint_degraded_contract 规则，检测 determination_contract/reactor_contract 场景报 weak_assertion 告警。4 个新测试通过。Closes biantaishabi2/unibo#1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)